### PR TITLE
docs: --origins のサンプル URL を example.com に変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ geonic me policies create '{
 ```bash
 geonic me api-keys create \
   --name "monitor-app" \
-  --origins "https://your-app.vercel.app" \
+  --origins "http://example.com" \
   --dpop-required \
   --policy "ngsi-ld-readonly"
 ```


### PR DESCRIPTION
## Summary

- `--origins` のサンプル URL を `https://your-app.vercel.app` から `http://example.com` に変更