### PR TITLE
ci: GitHub Actions で gh-pages への自動デプロイを設定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm install
+
+      - run: npm run build
+        env:
+          VITE_GEONICDB_URL: ${{ secrets.VITE_GEONICDB_URL }}
+          VITE_GEONICDB_TENANT: ${{ secrets.VITE_GEONICDB_TENANT }}
+          VITE_GEONICDB_API_KEY: ${{ secrets.VITE_GEONICDB_API_KEY }}
+          VITE_GEOLONIA_API_KEY: ${{ secrets.VITE_GEOLONIA_API_KEY }}
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
## Summary

- main へのマージ時に自動で GitHub Pages へデプロイ
- ビルド時の環境変数は Repository Secrets から注入
- `actions/deploy-pages` を使用した公式方式

## 設定済み Secrets

- `VITE_GEONICDB_URL`
- `VITE_GEONICDB_TENANT`
- `VITE_GEONICDB_API_KEY`
- `VITE_GEOLONIA_API_KEY`

## Test plan

- [ ] PR マージ後に Actions が起動することを確認
- [ ] GitHub Pages の URL でアプリが表示されることを確認
  - Settings → Pages → Source を `GitHub Actions` に設定してください