### PR TITLE
fix: vite.config.js に base オプションを追加してサブディレクトリ対応

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  base: process.env.BASE_URL || '/',
   server: {
     port: 8080,
   },


### PR DESCRIPTION
## Summary

- `base: process.env.BASE_URL || '/'` を追加
- GitHub Actions のビルド時に `BASE_URL=/gdb-monitor/` が渡され、JS/CSS のパスが `/gdb-monitor/assets/...` になる
- ローカル開発時は `BASE_URL` 未設定のため `/` のまま動作

## Root Cause

PR #3 のマージ時に `vite.config.js` の変更が含まれなかったため、JS のパスが `/assets/...` になり 404 が発生していた。