### PR TITLE
refactor: 統計カードを削除

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,19 +36,6 @@
   </div>
 
   <div class="side-panel">
-    <div class="panel-card stats-card">
-      <div class="card-label" id="panel-title">Entities</div>
-      <div class="stats-grid">
-        <div class="stat-box">
-          <div class="stat-value" id="stat-count">-</div>
-          <div class="stat-label">Total</div>
-        </div>
-        <div class="stat-box">
-          <div class="stat-value" id="stat-latest">-</div>
-          <div class="stat-label">Last Recv</div>
-        </div>
-      </div>
-    </div>
     <div class="panel-card feed-card">
       <div class="feed-header">
         <div class="feed-dot"></div>

--- a/src/app.js
+++ b/src/app.js
@@ -59,7 +59,6 @@ if (!ENTITY_TYPE) ENTITY_TYPE = '__none__';
 
 // UI のタイトル表示を更新
 document.getElementById('app-title').textContent = ENTITY_TYPE === '__none__' ? 'GeonicDB Monitor' : ENTITY_TYPE;
-document.getElementById('panel-title').textContent = ENTITY_TYPE === '__none__' ? '-' : ENTITY_TYPE;
 document.title = (ENTITY_TYPE === '__none__' ? '' : ENTITY_TYPE + ' — ') + 'GeonicDB Monitor';
 if (ENTITY_TYPE === '__none__') {
   document.querySelector('.header').style.display = 'none';
@@ -453,18 +452,6 @@ function selectEntity(id) {
 }
 
 // ============================================================
-// 統計表示
-// ============================================================
-
-var latestTime = null;
-
-function updateStats(list) {
-  document.getElementById('stat-count').textContent = list.length;
-  document.getElementById('stat-latest').textContent =
-    latestTime ? formatTime(latestTime) : '--:--';
-}
-
-// ============================================================
 // 地図レイヤー描画
 // ============================================================
 // MapLibre GL の data-driven styling を使い、選択状態に応じて
@@ -535,7 +522,6 @@ function renderEntities(list) {
       }
     });
   }
-  updateStats(list);
 }
 
 // ============================================================
@@ -640,11 +626,6 @@ map.on('style.load', function() { if (!mapReady) onMapReady(); });
 // なければ通常の NGSI-LD entities API にフォールバックする。
 // SDK の db.getEntities() は内部で認証ヘッダーを自動付与する。
 
-if (ENTITY_TYPE === '__none__') {
-  document.getElementById('stat-count').textContent = '-';
-  document.getElementById('stat-latest').textContent = '--:--';
-}
-
 var dataPromise = (ENTITY_TYPE !== '__none__')
   ? fetchTemporalEntities(ENTITY_TYPE).then(function(result) {
       if (result.length > 0) {
@@ -678,10 +659,9 @@ dataPromise && dataPromise
       );
       return;
     }
-    latestTime = new Date().toISOString();
     initFeed(entities);
     if (mapReady) { renderEntities(entities); }
-    else { pendingRender = entities; updateStats(entities); }
+    else { pendingRender = entities; }
     // 全エンティティが収まるように地図のビューを自動調整
     if (entities.length) {
       var bounds = new geolonia.LngLatBounds();
@@ -762,9 +742,7 @@ function handleEntity(msg, isNew) {
     }
     if (!found) entities.push(entity);
   }
-  latestTime = new Date().toISOString();
   if (mapReady) renderEntities(entities);
-  else updateStats(entities);
 
   addFeedItem(entity, isNew);
   showToast(getEntityName(entity));

--- a/src/style.css
+++ b/src/style.css
@@ -93,47 +93,7 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
   overflow: hidden;
 }
 
-/* ── 統計カード ── */
-.stats-card {
-  padding: 16px;
-}
-.stats-card .card-label {
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 1.2px;
-  color: rgba(255,255,255,0.35);
-  margin-bottom: 12px;
-}
-.stats-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-}
-.stat-box {
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.06);
-  border-radius: 10px;
-  padding: 12px;
-  text-align: center;
-}
-.stat-value {
-  font-size: 28px;
-  font-weight: 700;
-  font-family: 'JetBrains Mono', monospace;
-  background: linear-gradient(135deg, #00e5ff, #2979ff);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  line-height: 1.1;
-}
-.stat-label {
-  font-size: 9px;
-  font-weight: 500;
-  text-transform: uppercase;
-  letter-spacing: 1px;
-  color: rgba(255,255,255,0.35);
-  margin-top: 4px;
-}
+
 
 /* ── ライブフィード ── */
 .feed-card {


### PR DESCRIPTION
## Summary

サイドパネルの統計カード（TOTAL / LAST RECV）を削除。

- `index.html` から stats-card の HTML を削除
- `src/app.js` から `updateStats()`, `latestTime` 関連のコードを削除
- `src/style.css` から統計カードのスタイルを削除