### PR TITLE
fix: iOS でのパスワードポップアップと地図の高さを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
       <div class="type-picker-icon">&#9673;</div>
       <h2>GeonicDB Monitor</h2>
       <p>ログインしてモニターを開始</p>
-      <form id="login-form">
-        <input id="login-tenant" class="login-field" type="text" placeholder="テナント名（省略可）" autocomplete="organization" />
-        <input id="login-email" class="login-field" type="email" placeholder="メールアドレス" required autocomplete="email" />
-        <input id="login-password" class="login-field" type="password" placeholder="パスワード" required autocomplete="current-password" />
+      <form id="login-form" autocomplete="off">
+        <input id="login-tenant" class="login-field" type="text" placeholder="テナント名（省略可）" autocomplete="off" />
+        <input id="login-email" class="login-field" type="email" placeholder="メールアドレス" required autocomplete="off" />
+        <input id="login-password" class="login-field" type="password" placeholder="パスワード" required autocomplete="off" />
         <button type="submit" class="login-btn" id="login-btn">ログイン</button>
         <div class="login-error" id="login-error"></div>
       </form>

--- a/src/main.js
+++ b/src/main.js
@@ -41,35 +41,42 @@ window.handleLogout = handleLogout;
 (function() {
   var auth = getStoredAuth();
 
+  /** ログインフォームをDOMから削除してiOSのパスワード自動入力ポップアップを防止 */
+  function removeLoginForm() {
+    var form = document.getElementById('login-form');
+    if (form) form.remove();
+  }
+
   if (auth && auth.accessToken) {
     document.getElementById('login-overlay').classList.add('hidden');
+    removeLoginForm();
     // GeonicDB SDK はサーバーから動的にロードする（CDN ではなくサーバー固有のバージョンを使用）
     loadGeonicDBSDK(auth.url).then(function() {
       initApp(auth);
     }).catch(function(err) {
       console.error(err);
       clearAuth();
-      document.getElementById('login-overlay').classList.remove('hidden');
-      document.getElementById('login-error').textContent = 'セッションが無効です。再度ログインしてください。';
+      // フォームは既にDOMから削除済みなのでリロードしてログイン画面を再構築
+      location.href = location.pathname;
     });
   } else {
     document.getElementById('login-overlay').classList.remove('hidden');
-  }
-
-  document.getElementById('login-form').onsubmit = function(e) {
-    e.preventDefault();
-    var email = document.getElementById('login-email').value.trim();
-    var password = document.getElementById('login-password').value;
-    var tenant = document.getElementById('login-tenant').value.trim();
-    if (email && password) {
-      handleLogin(email, password, tenant).then(function(auth) {
-        return loadGeonicDBSDK(auth.url).then(function() {
-          document.getElementById('login-overlay').classList.add('hidden');
-          initApp(auth);
+    document.getElementById('login-form').onsubmit = function(e) {
+      e.preventDefault();
+      var email = document.getElementById('login-email').value.trim();
+      var password = document.getElementById('login-password').value;
+      var tenant = document.getElementById('login-tenant').value.trim();
+      if (email && password) {
+        handleLogin(email, password, tenant).then(function(auth) {
+          return loadGeonicDBSDK(auth.url).then(function() {
+            document.getElementById('login-overlay').classList.add('hidden');
+            removeLoginForm();
+            initApp(auth);
+          });
+        }).catch(function() {
+          // エラーは handleLogin 内で UI に表示済み
         });
-      }).catch(function() {
-        // エラーは handleLogin 内で UI に表示済み
-      });
-    }
-  };
+      }
+    };
+  }
 })();

--- a/src/style.css
+++ b/src/style.css
@@ -3,7 +3,7 @@
 * { margin: 0; padding: 0; box-sizing: border-box; }
 body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #0a0e1a; overflow: hidden; }
 
-#map { width: 100%; height: 100vh; }
+#map { width: 100%; height: 100dvh; }
 
 /* ── ヘッダー ── */
 .header {


### PR DESCRIPTION
## Summary
- ログイン済みでも iOS がパスワード自動入力ポップアップを表示する問題を修正（`autocomplete="off"` + ログイン後にフォームを DOM から削除）
- 地図の高さが iOS Safari でアドレスバー分ずれる問題を修正（`100vh` → `100dvh`）

## Test plan
- [ ] iOS Safari でログイン後にパスワードポップアップが表示されないことを確認
- [ ] iOS Safari で地図が画面全体に正しく表示され、上部が切れないことを確認
- [ ] ログインフォームが正常に動作することを確認
- [ ] SDK 読み込み失敗時にログイン画面に正しくリダイレクトされることを確認