### PR TITLE
fix: タイプ選択画面でセッション切れ時にログイン画面へリダイレクト

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,14 @@ if (!ENTITY_TYPE) {
   fetch(auth.url + '/ngsi-ld/v1/types', {
     headers: { 'Authorization': 'Bearer ' + auth.accessToken }
   })
-  .then(function(res) { return res.json(); })
+  .then(function(res) {
+    if (res.status === 401 || res.status === 403) {
+      clearAuth();
+      location.href = location.pathname;
+      throw new Error('Unauthorized');
+    }
+    return res.json();
+  })
   .then(function(types) {
     select.innerHTML = '<option value="" disabled selected>エンティティタイプを選択...</option>';
     types.forEach(function(t) {
@@ -47,7 +54,8 @@ if (!ENTITY_TYPE) {
       select.appendChild(opt);
     });
   })
-  .catch(function() {
+  .catch(function(err) {
+    if (err.message === 'Unauthorized') return;
     select.innerHTML = '<option value="" disabled selected>取得に失敗しました</option>';
   });
 }


### PR DESCRIPTION
## Summary
- `/types` API が 401/403 を返した場合に認証をクリアしてログイン画面にリダイレクトするように修正
- セッション切れ時にタイプ選択画面のまま止まってしまう問題を解消

## Test plan
- [ ] セッション切れ状態でページをリロードし、ログイン画面が表示されることを確認
- [ ] 正常なセッションでタイプ一覧が正しく取得・表示されることを確認