### PR TITLE
fix: autocomplete 属性を復元してパスワード入力補助を有効化

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
       <div class="type-picker-icon">&#9673;</div>
       <h2>GeonicDB Monitor</h2>
       <p>ログインしてモニターを開始</p>
-      <form id="login-form" autocomplete="off">
-        <input id="login-tenant" class="login-field" type="text" placeholder="テナント名（省略可）" autocomplete="off" />
-        <input id="login-email" class="login-field" type="email" placeholder="メールアドレス" required autocomplete="off" />
-        <input id="login-password" class="login-field" type="password" placeholder="パスワード" required autocomplete="off" />
+      <form id="login-form">
+        <input id="login-tenant" class="login-field" type="text" placeholder="テナント名（省略可）" autocomplete="organization" />
+        <input id="login-email" class="login-field" type="email" placeholder="メールアドレス" required autocomplete="email" />
+        <input id="login-password" class="login-field" type="password" placeholder="パスワード" required autocomplete="current-password" />
         <button type="submit" class="login-btn" id="login-btn">ログイン</button>
         <div class="login-error" id="login-error"></div>
       </form>


### PR DESCRIPTION
## Summary
- `autocomplete="off"` を元の値に復元し、ログイン画面でパスワード入力補助が動作するように修正
- ログイン済み時のポップアップ抑制はフォームの DOM 削除で対応済みのため `autocomplete="off"` は不要

## Test plan
- [ ] ログイン画面でパスワード入力補助が表示されることを確認
- [ ] ログイン後にパスワードポップアップが表示されないことを確認