### PR TITLE
fix: モバイルで fitBounds のパディングを調整

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -710,7 +710,11 @@ dataPromise && dataPromise
         }
       });
       if (!bounds.isEmpty()) {
-        map.fitBounds(bounds, { padding: { top: 80, bottom: 40, left: 300, right: 40 }, duration: 1000, maxZoom: 16 });
+        var isMobile = window.innerWidth <= 768;
+        var padding = isMobile
+          ? { top: 80, bottom: 60, left: 40, right: 40 }
+          : { top: 80, bottom: 40, left: 300, right: 40 };
+        map.fitBounds(bounds, { padding: padding, duration: 1000, maxZoom: 16 });
       }
     }
   })


### PR DESCRIPTION
## Summary
- `fitBounds` の `left: 300` パディングがモバイルでもデスクトップ用サイドパネル幅で適用され、エンティティが右端に寄る問題を修正
- モバイル (768px以下) では均等なパディング (`left: 40`) を使用

## Test plan
- [ ] モバイルでエンティティが画面中央付近に収まることを確認
- [ ] デスクトップではサイドパネル分の左パディングが維持されることを確認