### PR TITLE
fix: テナント名フィールドの autocomplete を off に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
       <h2>GeonicDB Monitor</h2>
       <p>ログインしてモニターを開始</p>
       <form id="login-form">
-        <input id="login-tenant" class="login-field" type="text" placeholder="テナント名" required autocomplete="organization" />
+        <input id="login-tenant" class="login-field" type="text" placeholder="テナント名" required autocomplete="off" />
         <input id="login-email" class="login-field" type="email" placeholder="メールアドレス" required autocomplete="email" />
         <input id="login-password" class="login-field" type="password" placeholder="パスワード" required autocomplete="current-password" />
         <button type="submit" class="login-btn" id="login-btn">ログイン</button>


### PR DESCRIPTION
## Summary
- テナント名フィールドの `autocomplete="organization"` を `autocomplete="off"` に変更
- ブラウザがテナント名をユーザー名と誤認してパスワード自動入力が正しく動作しない問題を修正
- テナント名はアプリ側で localStorage から復元するためブラウザの自動補完は不要

## Test plan
- [ ] ログイン画面でテナント名がブラウザのユーザー名候補に表示されないことを確認
- [ ] メールアドレス・パスワードの自動補完が正常に動作することを確認