### PR TITLE
fix: 地図の回転・ピッチを無効化

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -87,7 +87,10 @@ var map = new geolonia.Map({
   zoom: 10,
   minZoom: 2,
   maxZoom: 16,
-  renderWorldCopies: false
+  renderWorldCopies: false,
+  dragRotate: false,
+  touchPitch: false,
+  pitchWithRotate: false
 });
 
 


### PR DESCRIPTION
dragRotate, touchPitch, pitchWithRotate を無効化