### PR TITLE
feat: OFFLINE表示タップで手動再接続

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -920,17 +920,29 @@ if (ENTITY_TYPE !== '__none__') {
 }
 
 // 接続状態の UI 表示
+var wsStatus = wsDot.closest('.ws-status');
+
 db.on('connected', function() {
   wsDot.className = 'ws-dot connected';
   wsLabel.textContent = 'LIVE';
+  wsStatus.classList.remove('tappable');
 });
 db.on('disconnected', function() {
   wsDot.className = 'ws-dot';
   wsLabel.textContent = 'OFFLINE';
+  wsStatus.classList.add('tappable');
 });
 db.on('reconnecting', function() {
   wsDot.className = 'ws-dot connecting';
   wsLabel.textContent = 'RECONNECTING';
+  wsStatus.classList.remove('tappable');
+});
+
+// OFFLINE 表示をタップして手動再接続
+wsStatus.addEventListener('click', function() {
+  if (!wsStatus.classList.contains('tappable')) return;
+  wsStatus.classList.remove('tappable');
+  db._reconnect();
 });
 // トークン関連のエラーはセッション切れとしてログイン画面に戻す
 db.on('error', function(err) {

--- a/src/style.css
+++ b/src/style.css
@@ -81,6 +81,8 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
   animation: glow-pulse 2s ease-in-out infinite;
 }
 .ws-dot.connecting { background: #ff9800; }
+.ws-status.tappable { cursor: pointer; }
+.ws-status.tappable:active { opacity: 0.7; }
 
 @keyframes glow-pulse {
   0%, 100% { box-shadow: 0 0 6px rgba(76,175,80,0.5); }


### PR DESCRIPTION
## Summary
- WebSocket切断時のOFFLINE表示をタップすると即座に再接続を開始する
- 自動再接続のバックオフ待ち中でもユーザー操作で即復帰可能
- LIVE / RECONNECTING 中はタップ無効（`tappable` クラスで制御）

## Test plan
- [ ] WebSocket切断状態でOFFLINE表示をタップし、再接続が開始されることを確認
- [ ] LIVE状態でタップしても何も起きないことを確認
- [ ] RECONNECTING中にタップしても二重接続にならないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * WebSocket接続がオフラインの場合、ステータス表示をタップして手動で再接続できるようになりました。

* **スタイル**
  * オフライン時のステータス表示にポインターカーソルと押下時の視覚フィードバックを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->