### PR TITLE
fix(ui): WebSocket ステータスラベル RECONNECTING → CONNECTING に変更

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -906,7 +906,7 @@ db.on('disconnected', function() {
 });
 db.on('reconnecting', function() {
   wsDot.className = 'ws-dot connecting';
-  wsLabel.textContent = 'RECONNECTING';
+  wsLabel.textContent = 'CONNECTING';
   wsBadge.classList.remove('tappable');
 });
 


### PR DESCRIPTION
## Summary

- WebSocket 再接続中のステータスラベルを `RECONNECTING` → `CONNECTING` に短縮
- 文字数が長くプルダウンメニューと干渉する問題を修正

## Test plan

- [ ] 再接続時にラベルが `CONNECTING` と表示されることを確認
- [ ] プルダウンメニューとの干渉がないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * WebSocket再接続時の接続状態表示を改善しました。再接続中の画面表示がより正確になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->