### PR TITLE
feat(ui): サイドバーにエンティティの @context を表示

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -420,6 +420,7 @@ function addFeedItem(entity, isNew) {
     '<div class="feed-info">' +
       '<div class="feed-name">' + name + '</div>' +
       '<div class="feed-meta">' + time + '</div>' +
+      (entity['@context'] ? '<div class="feed-context">' + (Array.isArray(entity['@context']) ? entity['@context'].join(', ') : entity['@context']) + '</div>' : '') +
     '</div>';
   item.onclick = function() {
     var geo = findGeoProperty(entity);
@@ -449,6 +450,7 @@ function initFeed(list) {
       '<div class="feed-info">' +
         '<div class="feed-name">' + name + '</div>' +
         '<div class="feed-meta">' + e.id + '</div>' +
+        (e['@context'] ? '<div class="feed-context">' + (Array.isArray(e['@context']) ? e['@context'].join(', ') : e['@context']) + '</div>' : '') +
       '</div>';
     item.onclick = (function(ent) {
       return function() {

--- a/src/style.css
+++ b/src/style.css
@@ -182,6 +182,13 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.feed-context {
+  font-size: 10px;
+  color: rgba(255,255,255,0.18);
+  font-family: 'JetBrains Mono', monospace;
+  margin-top: 1px;
+  word-break: break-all;
+}
 
 /* ── タイプ選択オーバーレイ ── */
 .type-overlay {


### PR DESCRIPTION
## Summary

- サイドバーのフィードアイテムで、エンティティ ID の下に `@context` URL を表示
- 配列の場合はカンマ区切りで全 URL を表示
- `@context` が存在しないエンティティでは非表示
- URL は折り返し表示（truncate しない）

## Test plan

- [x] ローカルサーバーで表示確認済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * フィードアイテムのコンテキスト情報表示に対応しました。エンティティがコンテキスト情報を含む場合、フィード内に小さなテキストで表示されます。複数のコンテキスト値はコンマで区切られて表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->