### PR TITLE
fix: FOUC防止、SDK API変更対応、fetch→SDK移行

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
 # GeonicDB
 VITE_GEONICDB_URL=https://geonicdb.geolonia.com
-VITE_GEONICDB_API_KEY=gdb_xxxxx
 
 # Geolonia Maps (optional)
 VITE_GEOLONIA_API_KEY=YOUR-API-KEY

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#1a1a1a">
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="manifest" href="manifest.json">
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
@@ -12,6 +12,7 @@
   <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
   <link rel="apple-touch-icon" href="icons/apple-touch-icon.png">
   <title>GeonicDB Pulse</title>
+  <style>html{background:#212121}body{visibility:hidden}</style>
   <!-- OGP -->
   <meta property="og:title" content="GeonicDB Pulse">
   <meta property="og:description" content="GeonicDB のエンティティをリアルタイムに地図上で可視化するモニターアプリ">

--- a/src/app.js
+++ b/src/app.js
@@ -19,6 +19,33 @@ mapStyle.sprite = location.origin + import.meta.env.BASE_URL + 'sprites/gsi';
 export function initApp(auth) {
 
 // ============================================================
+// GeonicDB クライアント初期化
+// ============================================================
+// GeonicDB SDK のインスタンスを作成し、Bearer JWT トークンをセットする。
+// SDK はデフォルトで DPoP (Proof of Work) 認証を使うが、
+// ログイン API で取得した Bearer トークンを直接セットすることで DPoP をスキップできる。
+var db = new GeonicDB({
+  baseUrl: auth.url,
+  tenant: auth.tenant
+});
+
+// Bearer JWT トークンを SDK 公開 API でセット（DPoP フローをスキップ）
+db.setCredentials({
+  token: auth.accessToken,
+  tokenType: 'Bearer',
+  expiresIn: auth.expiresIn,
+  refreshToken: auth.refreshToken,
+});
+
+// SDK がトークンをリフレッシュした際に localStorage と同期する
+db.on('tokenRefresh', function(creds) {
+  auth.accessToken = creds.token;
+  if (creds.refreshToken !== undefined) auth.refreshToken = creds.refreshToken;
+  if (creds.expiresIn !== undefined) auth.expiresIn = creds.expiresIn;
+  storeAuth(auth);
+});
+
+// ============================================================
 // エンティティタイプの選択
 // ============================================================
 // URL の ?type= パラメータでモニター対象のエンティティタイプを指定する。
@@ -34,19 +61,9 @@ if (!ENTITY_TYPE) {
     var val = document.getElementById('type-input').value;
     if (val) location.href = '?type=' + encodeURIComponent(val);
   };
-  // NGSI-LD /types API でエンティティタイプ一覧を取得
+  // NGSI-LD /types API でエンティティタイプ一覧を取得（SDK経由で認証ヘッダー自動付与）
   var select = document.getElementById('type-input');
-  fetch(auth.url + '/ngsi-ld/v1/types', {
-    headers: { 'Authorization': 'Bearer ' + auth.accessToken }
-  })
-  .then(function(res) {
-    if (res.status === 401 || res.status === 403) {
-      clearAuth();
-      location.href = location.pathname;
-      throw new Error('Unauthorized');
-    }
-    return res.json();
-  })
+  db.request('GET', '/ngsi-ld/v1/types')
   .then(function(types) {
     select.innerHTML = '<option value="" disabled selected>エンティティタイプを選択...</option>';
     types.forEach(function(t) {
@@ -82,11 +99,8 @@ if (ENTITY_TYPE !== '__none__') {
   currentOpt.selected = true;
   appTypeSelect.appendChild(currentOpt);
 
-  // タイプ一覧を非同期で取得してプルダウンに追加
-  fetch(auth.url + '/ngsi-ld/v1/types', {
-    headers: { 'Authorization': 'Bearer ' + auth.accessToken }
-  })
-  .then(function(res) { return res.json(); })
+  // タイプ一覧を非同期で取得してプルダウンに追加（SDK経由で認証ヘッダー自動付与）
+  db.request('GET', '/ngsi-ld/v1/types')
   .then(function(types) {
     appTypeSelect.innerHTML = '';
     types.forEach(function(t) {
@@ -157,33 +171,6 @@ map.on('dragstart', function() { selectEntity(null); popup.remove(); });
 function getFlyZoom(defaultZoom) {
   return userZoom !== null ? userZoom : defaultZoom;
 }
-
-// ============================================================
-// GeonicDB クライアント初期化
-// ============================================================
-// GeonicDB SDK のインスタンスを作成し、Bearer JWT トークンをセットする。
-// SDK はデフォルトで DPoP (Proof of Work) 認証を使うが、
-// ログイン API で取得した Bearer トークンを直接セットすることで DPoP をスキップできる。
-var db = new GeonicDB({
-  baseUrl: auth.url,
-  tenant: auth.tenant
-});
-
-// Bearer JWT トークンを SDK 公開 API でセット（DPoP フローをスキップ）
-db.setCredentials({
-  token: auth.accessToken,
-  tokenType: 'Bearer',
-  expiresIn: auth.expiresIn,
-  refreshToken: auth.refreshToken,
-});
-
-// SDK がトークンをリフレッシュした際に localStorage と同期する
-db.onTokenRefresh(function(creds) {
-  auth.accessToken = creds.token;
-  if (creds.refreshToken !== undefined) auth.refreshToken = creds.refreshToken;
-  if (creds.expiresIn !== undefined) auth.expiresIn = creds.expiresIn;
-  storeAuth(auth);
-});
 
 // トークンリフレッシュ失敗時はセッション切れとしてログイン画面に戻す
 db.on('error', function(err) {
@@ -256,10 +243,6 @@ function flattenTemporal(te) {
  */
 function fetchTemporalEntities(type) {
   var temporalPromise = db.request('GET', '/ngsi-ld/v1/temporal/entities?type=' + encodeURIComponent(type) + '&limit=1000')
-    .then(function(res) {
-      if (!res.ok) return res.json().then(function(e) { throw new Error(e.detail || 'Temporal query failed'); });
-      return res.json();
-    })
     .then(function(rawEntities) {
       if (!Array.isArray(rawEntities)) rawEntities = [];
       rawEntities.forEach(function(te) { temporalRaw[te.id] = te; });

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap');
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
-body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #1a1a1a; overflow: hidden; }
+body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; background: #1a1a1a; overflow: hidden; visibility: visible; }
 
 #map { width: 100%; height: 100dvh; }
 


### PR DESCRIPTION
## Summary
- リロード時のFOUC（スタイル未適用コンテンツのフラッシュ）を防止
- GeonicDB SDK の API 変更に追従（`onTokenRefresh` → `on('tokenRefresh')`）
- `fetch` 直接呼び出しを `db.request()` に統一し、サンプルアプリとしてSDKの使い方を示す
- 未使用の `VITE_GEONICDB_API_KEY` を `.env.example` から削除
- 非推奨の `apple-mobile-web-app-capable` を `mobile-web-app-capable` に更新

## Test plan
- [ ] リロード時に不完全なコンテンツが一瞬表示されないことを確認
- [ ] ログイン → エンティティタイプ選択 → 地図表示が正常に動作すること
- [ ] タイプ選択画面でエンティティタイプ一覧が表示されること
- [ ] WebSocket接続（LIVE表示）が正常に動作すること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ページの初期読み込み時の表示処理を改善しました
  * ページの背景色とビジビリティ設定を調整しました

* **チューア**
  * iOSウェブアプリ機能の設定を更新しました
  * 環境設定ファイルを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->