### PR TITLE
feat: エンティティ件数インジケーター

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
   </div>
 
   <div class="toast" id="toast"></div>
+  <div class="entity-count" id="entity-count"></div>
 
   <div class="type-overlay hidden" id="type-overlay">
     <div class="type-picker">

--- a/src/app.js
+++ b/src/app.js
@@ -221,6 +221,31 @@ function fetchTemporalEntities(type) {
 var PAGE_SIZE = 100;
 var hasMore = true;
 var paginationOffset = 0; // ページネーション専用の offset（WebSocket 追加分を含まない）
+var totalCount = null;
+var entityCountEl = document.getElementById('entity-count');
+
+/** 画面下部の件数インジケーターを更新する */
+function updateEntityCount() {
+  if (!entityCountEl || totalCount === null) return;
+  entityCountEl.textContent = entities.length + ' / ' + totalCount;
+  entityCountEl.classList.add('visible');
+}
+
+/**
+ * エンティティ総数を count=true&limit=0 で取得する。
+ * db.request() はレスポンスヘッダーにアクセスできないため直接 fetch する。
+ * ref: geolonia/geonicdb#907
+ */
+function fetchTotalCount(type) {
+  var url = auth.url + '/ngsi-ld/v1/entities?type=' + encodeURIComponent(type) + '&count=true&limit=0';
+  return fetch(url, {
+    headers: { 'Authorization': 'Bearer ' + auth.accessToken }
+  }).then(function(res) {
+    var count = res.headers.get('NGSILD-Results-Count');
+    if (count !== null) totalCount = parseInt(count, 10);
+    updateEntityCount();
+  }).catch(function() {});
+}
 
 /** createdAt の降順でソート */
 function sortByCreatedAt(arr) {
@@ -273,6 +298,7 @@ function loadNextPage() {
       sortByCreatedAt(result);
       result.forEach(function(e) { entities.push(e); });
       appendFeedItems(result);
+      updateEntityCount();
       if (mapApi.isMapReady()) mapApi.renderEntities(entities);
       // 追加分を含めて地図のビューを自動調整
       fitBoundsToEntities();
@@ -318,6 +344,8 @@ dataPromise && dataPromise
     }
     initFeed(feedDeps, loadNextPage);
     appendFeedItems(entities);
+    updateEntityCount();
+    fetchTotalCount(ENTITY_TYPE);
     if (mapApi.isMapReady()) { mapApi.renderEntities(entities); }
     else { mapApi.setPendingRender(entities); }
     // 初期データ取得完了後に WebSocket 接続を開始し、REST スナップショットとの競合を防ぐ
@@ -394,6 +422,7 @@ function handleEntity(msg, isNew) {
 
   addFeedItem(entity, isNew, feedDeps);
   showToast(getEntityName(entity));
+  updateEntityCount();
 
   // 更新されたエンティティの位置にカメラを移動
   var geo = findGeoProperty(entity);

--- a/src/style.css
+++ b/src/style.css
@@ -298,6 +298,25 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
   transform: translateY(0);
 }
 
+.entity-count {
+  position: absolute;
+  bottom: 4px; left: 50%;
+  transform: translateX(-50%);
+  z-index: 20;
+  pointer-events: none;
+  background: rgba(30,30,30,0.9);
+  border: 1px solid rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.7);
+  padding: 4px 10px;
+  border-radius: 12px;
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+.entity-count.visible { opacity: 1; }
+
 /* ── ポップアップ ── */
 .maplibregl-popup { max-width: 420px !important; }
 .maplibregl-popup-tip { display: none !important; }


### PR DESCRIPTION
## Summary

- 画面下部中央に「100 / 448」形式で現在の表示件数 / 総数を表示する角丸バッジを追加
- `count=true&limit=0` で NGSILD-Results-Count ヘッダーから総数を取得
- 総数の取得完了後に表示（ロード中は非表示）
- ページ追加・WebSocket 追加時にリアルタイムで件数を更新

## Related

- geolonia/geonicdb#907 — SDK に count API の追加を提案

## Test plan

- [ ] 初回ロード時、総数取得後に「100 / 448」のようなバッジが表示されること
- [ ] サイドバーをスクロールしてページ追加すると左の数字が増えること
- [ ] WebSocket でエンティティが追加されると左の数字が増えること
- [ ] アトリビューションと上下位置が揃っていること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エンティティカウント表示機能を追加しました。アプリケーション上に現在表示されているエンティティ数と全体の総数をリアルタイムで表示するようになりました。データの更新時やスクロール時に自動的に更新されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->