### PR TITLE
refactor: エンティティ総数取得を SDK の db.count() に置き換え

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.1.1"
+        "@geolonia/geonicdb-sdk": "^0.2.1"
       },
       "devDependencies": {
         "vite": "^8.0.1",
@@ -50,10 +50,10 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.1.1.tgz",
-      "integrity": "sha512-7CsVSBHztlAtnX9mqv2NEppSqsKFvQLfSNxoSrRG7Qx4k5mWh/yUbwPcdw7czRAlXuaXKqE1bobLWsSupNAPNg==",
-      "license": "AGPL-3.0-or-later"
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.2.1.tgz",
+      "integrity": "sha512-/i9i4TcRx9oJLIptWiGLChyI407bxd/bOZO/okksJeVXNXbCe24AYbVHWB4Q+Ki/t3NPJiwH+gACSLEjmz0mwg==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.1.1"
+    "@geolonia/geonicdb-sdk": "^0.2.1"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -231,13 +231,6 @@ function updateEntityCount() {
   entityCountEl.classList.add('visible');
 }
 
-/** エンティティ総数を SDK の count() で取得する */
-function fetchTotalCount(type) {
-  return db.count({ type: type }).then(function(count) {
-    totalCount = count;
-    updateEntityCount();
-  }).catch(function() {});
-}
 
 /** createdAt の降順でソート */
 function sortByCreatedAt(arr) {
@@ -337,7 +330,10 @@ dataPromise && dataPromise
     initFeed(feedDeps, loadNextPage);
     appendFeedItems(entities);
     updateEntityCount();
-    fetchTotalCount(ENTITY_TYPE);
+    db.count({ type: ENTITY_TYPE }).then(function(count) {
+      totalCount = count;
+      updateEntityCount();
+    }).catch(function() {});
     if (mapApi.isMapReady()) { mapApi.renderEntities(entities); }
     else { mapApi.setPendingRender(entities); }
     // 初期データ取得完了後に WebSocket 接続を開始し、REST スナップショットとの競合を防ぐ

--- a/src/app.js
+++ b/src/app.js
@@ -231,18 +231,10 @@ function updateEntityCount() {
   entityCountEl.classList.add('visible');
 }
 
-/**
- * エンティティ総数を count=true&limit=0 で取得する。
- * db.request() はレスポンスヘッダーにアクセスできないため直接 fetch する。
- * ref: geolonia/geonicdb#907
- */
+/** エンティティ総数を SDK の count() で取得する */
 function fetchTotalCount(type) {
-  var url = auth.url + '/ngsi-ld/v1/entities?type=' + encodeURIComponent(type) + '&count=true&limit=0';
-  return fetch(url, {
-    headers: { 'Authorization': 'Bearer ' + auth.accessToken }
-  }).then(function(res) {
-    var count = res.headers.get('NGSILD-Results-Count');
-    if (count !== null) totalCount = parseInt(count, 10);
+  return db.count({ type: type }).then(function(count) {
+    totalCount = count;
     updateEntityCount();
   }).catch(function() {});
 }


### PR DESCRIPTION
## Summary

- エンティティ総数の取得を、直接 `fetch` + `NGSILD-Results-Count` ヘッダー読み取りから SDK の `db.count()` メソッドに置き換え
- `@geolonia/geonicdb-sdk` を `0.1.1` → `0.2.1` にアップデート

ref: geolonia/geonicdb#907

## Test plan

- [ ] アプリにログインし、画面下部のエンティティ件数インジケーター（`X / Y`）が正しく表示されることを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **更新**
  * GeonicDB SDK を v0.2.x 系に更新しました。

* **改善**
  * 起動時のエンティティ総数取得を SDK のカウント機能に切替え、集計処理を簡素化して安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->