### PR TITLE
fix: ドラッグ時の地図操作が重くなる不具合を修正

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -117,6 +117,7 @@ export function initMap(ctx) {
     sheetOverlay.classList.add('visible');
   }
   function closeBottomSheet() {
+    if (!sheetEl.classList.contains('open')) return;
     sheetEl.classList.remove('open');
     sheetOverlay.classList.remove('visible');
     selectEntity(null);


### PR DESCRIPTION
## Summary
- `closeBottomSheet()` がボトムシートの開閉状態を確認せず、`dragstart` のたびに `selectEntity(null)` (GeoJSON再構築) と `map.easeTo()` (アニメーション) を実行していた
- ボトムシートが閉じている場合は早期リターンするガードを追加し、不要な処理をスキップ

## Test plan
- [ ] ボトムシートを開かずに地図をドラッグしてスムーズに動くこと
- [ ] ボトムシートを開いた状態で地図をドラッグするとボトムシートが閉じること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ボトムシートが既に閉じている場合の不要な処理を削減し、パフォーマンスを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->