### PR TITLE
fix: ボトムシート表示時にサイドバーが閉じられない不具合を修正

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -680,7 +680,7 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
     transform: translateX(-100%);
     transition: transform 0.3s cubic-bezier(0.16, 1, 0.3, 1);
     pointer-events: auto;
-    z-index: 10;
+    z-index: 31;
   }
   .side-panel.open {
     transform: translateX(0);

--- a/src/style.css
+++ b/src/style.css
@@ -10,7 +10,7 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
 .header {
   position: absolute;
   top: 12px; left: 12px; right: 12px;
-  z-index: 10;
+  z-index: 31;
   background: rgba(20,20,20,0.8);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -91,7 +91,7 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
 .side-panel {
   position: absolute;
   top: 70px; left: 12px; bottom: 12px;
-  z-index: 10;
+  z-index: 31;
   width: 280px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- ボトムシートのオーバーレイ (`z-index: 29`) がヘッダー・サイドパネル (`z-index: 10`) より上にあり、閉じるボタンへのクリックがオーバーレイに吸われていた
- ヘッダーとサイドパネルの `z-index` を `31` に引き上げ、ボトムシートより常に上に配置

## Test plan
- [ ] サイドバーからエンティティを選択してボトムシートを開く
- [ ] サイドバーの閉じるボタン（≡）をタップしてサイドバーが閉じること
- [ ] ボトムシートが閉じるのではなくサイドバーが閉じること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ヘッダーとサイドパネルの重なり順を上げ、これらの要素が他のコンテンツに覆われず常に前面に表示されるようにしました。サイドパネルが非表示や移動中の状態でも確実に前面に表示されるよう調整しています。ユーザー操作時の表示崩れや重なりによる視認性の問題を改善します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->