### PR TITLE
fix: PC表示でサイドバーとボトムシートの重なりを解消

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -320,7 +320,7 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
 /* ── ボトムシート ── */
 .bottom-sheet {
   position: fixed;
-  bottom: 0; left: 0; right: 0;
+  bottom: 0; left: 304px; right: 0;
   z-index: 30;
   background: #2a2a2a;
   border-top-left-radius: 16px;
@@ -699,6 +699,10 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
   .panel-overlay.visible {
     opacity: 1;
     pointer-events: auto;
+  }
+
+  .bottom-sheet {
+    left: 0;
   }
 
   .toast {


### PR DESCRIPTION
## Summary
- デスクトップではボトムシートの `left` を `304px`（サイドバー280px + 余白）に設定し、サイドバーとの重なりを解消
- モバイル（768px以下）では `left: 0` に戻して全幅表示を維持

## Test plan
- [ ] PC でサイドバーとボトムシートが重ならないこと
- [ ] モバイルではボトムシートが全幅で表示されること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **スタイル**
  * ボトムシートのレイアウトをサイドパネルに対応するよう調整しました。デスクトップではサイドパネルのスペースを確保し、モバイル環境では従来のフルワイド表示に戻ります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->