### PR TITLE
fix: ラベルのタップ対応とサイドバー幅を考慮した地図中央配置

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -118,6 +118,7 @@ var feedDeps = {
   map: map,
   selectEntity: mapApi.selectEntity,
   getFlyZoom: mapApi.getFlyZoom,
+  sidebarPadding: mapApi.sidebarPadding,
   openPopupForEntity: mapApi.openPopupForEntity
 };
 
@@ -431,7 +432,7 @@ function handleEntity(msg, isNew) {
   // 更新されたエンティティの位置にカメラを移動
   var geo = findGeoProperty(entity);
   if (geo && geo.value) {
-    map.flyTo({ center: geo.value.coordinates, zoom: mapApi.getFlyZoom(16), duration: 1500 });
+    map.flyTo({ center: geo.value.coordinates, zoom: mapApi.getFlyZoom(16), duration: 1500, padding: { left: mapApi.sidebarPadding() } });
   }
 }
 

--- a/src/feed.js
+++ b/src/feed.js
@@ -79,7 +79,7 @@ function createEntityFeedItem(e, deps) {
     var geo = findGeoProperty(e);
     if (geo && geo.value) {
       deps.selectEntity(e.id);
-      deps.map.flyTo({ center: geo.value.coordinates, zoom: 16, duration: 1200 });
+      deps.map.flyTo({ center: geo.value.coordinates, zoom: 16, duration: 1200, padding: { left: deps.sidebarPadding() } });
       setTimeout(function() { deps.openPopupForEntity(e.id); }, 1300);
     }
   });
@@ -122,7 +122,7 @@ export function addFeedItem(entity, isNew, deps) {
     var geo = findGeoProperty(entity);
     if (geo && geo.value) {
       deps.selectEntity(entity.id);
-      deps.map.flyTo({ center: geo.value.coordinates, zoom: 16, duration: 1200 });
+      deps.map.flyTo({ center: geo.value.coordinates, zoom: 16, duration: 1200, padding: { left: deps.sidebarPadding() } });
       setTimeout(function() { deps.openPopupForEntity(entity.id); }, 1300);
     }
   });

--- a/src/map.js
+++ b/src/map.js
@@ -116,12 +116,17 @@ export function initMap(ctx) {
     sheetEl.classList.add('open');
     sheetOverlay.classList.add('visible');
   }
+  /** デスクトップ時のサイドバー幅分の左パディングを返す */
+  function sidebarPadding() {
+    return window.innerWidth > 768 ? 300 : 0;
+  }
+
   function closeBottomSheet() {
     if (!sheetEl.classList.contains('open')) return;
     sheetEl.classList.remove('open');
     sheetOverlay.classList.remove('visible');
     selectEntity(null);
-    map.easeTo({ padding: { bottom: 0 }, duration: 300 });
+    map.easeTo({ padding: { bottom: 0, left: 0 }, duration: 300 });
   }
 
   // マップ準備完了ハンドラ
@@ -132,8 +137,11 @@ export function initMap(ctx) {
       map.setLayoutProperty('road_shield', 'visibility', 'none');
     }
     map.on('click', 'entity-points', showPopup);
+    map.on('click', 'entity-labels', showPopup);
     map.on('mouseenter', 'entity-points', function() { map.getCanvas().style.cursor = 'pointer'; });
     map.on('mouseleave', 'entity-points', function() { map.getCanvas().style.cursor = ''; });
+    map.on('mouseenter', 'entity-labels', function() { map.getCanvas().style.cursor = 'pointer'; });
+    map.on('mouseleave', 'entity-labels', function() { map.getCanvas().style.cursor = ''; });
     // データ取得が地図ロードより先に完了していた場合、ここで描画する
     if (pendingRender) {
       renderEntities(pendingRender);
@@ -419,9 +427,9 @@ export function initMap(ctx) {
 
     openBottomSheet(headerEl, bodyEl);
     selectEntity(entityId);
-    // ボトムシートの高さ分パディングして、見えている地図領域の中央にポイントを配置
+    // ボトムシートの高さ・サイドバーの幅を考慮して、見えている地図領域の中央にポイントを配置
     var sheetHeight = sheetEl.offsetHeight || 0;
-    map.easeTo({ center: coords, padding: { bottom: sheetHeight }, duration: 400 });
+    map.easeTo({ center: coords, padding: { bottom: sheetHeight, left: sidebarPadding() }, duration: 400 });
   }
 
   function showPopup(ev) {
@@ -458,6 +466,7 @@ export function initMap(ctx) {
     selectEntity: selectEntity,
     openPopupForEntity: openPopupForEntity,
     getFlyZoom: getFlyZoom,
+    sidebarPadding: sidebarPadding,
     isMapReady: isMapReady,
     setPendingRender: setPendingRender,
     showError: showError


### PR DESCRIPTION
## Summary
- エンティティのラベルテキスト（`entity-labels` レイヤー）をクリック/タップ可能にした。サークルだけでなくラベルからもエンティティを選択できる
- デスクトップでサイドバーが表示されている時、エンティティ選択時の地図中央配置がサイドバー幅（300px）を考慮するようになった。`easeTo`/`flyTo` に `padding: { left: sidebarPadding() }` を追加

## Changes
- `src/map.js`: `entity-labels` にクリック/ホバーハンドラ追加、`sidebarPadding()` ヘルパー追加、`openPopupForEntity` と `closeBottomSheet` のパディング更新
- `src/feed.js`: フィードアイテムクリック時の `flyTo` にサイドバーパディング追加
- `src/app.js`: WebSocket 受信時の `flyTo` にサイドバーパディング追加、`feedDeps` に `sidebarPadding` を追加

## Test plan
- [ ] モバイル: エンティティのサークルをタップ → ポップアップ表示・中央配置される
- [ ] モバイル: エンティティのラベルをタップ → ポップアップ表示・中央配置される
- [ ] PC: エンティティのラベルをクリック → ポップアップ表示
- [ ] PC: エンティティ選択時、サイドバー右側の可視領域の中央にポイントが配置される
- [ ] PC: サイドバーのフィードアイテムクリック → サイドバー右側の中央に flyTo
- [ ] PC: ボトムシートを閉じた後、パディングがリセットされる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * サイドバーの幅を考慮したマップパディング処理が実装されました。エンティティフォーカス時にマップアニメーションでサイドバー領域との干渉が解消されました。

* **新機能**
  * エンティティラベルレイヤーにクリック操作とホバーアクション（ポインターカーソル表示）が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->