### PR TITLE
fix: エンティティ選択の操作性を改善

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -277,6 +277,9 @@ export function initMap(ctx) {
         type: 'circle',
         source: 'entities',
         filter: ['!', ['has', 'point_count']],
+        layout: {
+          'circle-sort-key': ['get', 'selected']
+        },
         paint: {
           'circle-radius': ['case', ['==', ['get', 'selected'], 1], 38, 30],
           'circle-color': ['case', ['==', ['get', 'selected'], 1], '#ff1744', '#00b0ff'],
@@ -290,6 +293,9 @@ export function initMap(ctx) {
         type: 'circle',
         source: 'entities',
         filter: ['!', ['has', 'point_count']],
+        layout: {
+          'circle-sort-key': ['get', 'selected']
+        },
         paint: {
           'circle-radius': ['case', ['==', ['get', 'selected'], 1], 22, 18],
           'circle-color': ['case', ['==', ['get', 'selected'], 1], '#ff1744', '#00b0ff'],
@@ -302,6 +308,9 @@ export function initMap(ctx) {
         type: 'circle',
         source: 'entities',
         filter: ['!', ['has', 'point_count']],
+        layout: {
+          'circle-sort-key': ['get', 'selected']
+        },
         paint: {
           'circle-radius': ['case', ['==', ['get', 'selected'], 1], 10, 8],
           'circle-color': ['case', ['==', ['get', 'selected'], 1], '#ff5252', '#00e5ff'],
@@ -317,6 +326,7 @@ export function initMap(ctx) {
         source: 'entities',
         filter: ['!', ['has', 'point_count']],
         layout: {
+          'symbol-sort-key': ['get', 'selected'],
           'text-field': ['get', 'name'],
           'text-size': 11,
           'text-font': ['Noto Sans CJK JP Bold'],

--- a/src/map.js
+++ b/src/map.js
@@ -106,7 +106,20 @@ export function initMap(ctx) {
   var sheetBody = document.getElementById('bottom-sheet-body');
   var sheetOverlay = document.getElementById('bottom-sheet-overlay');
   document.getElementById('bottom-sheet-close').addEventListener('click', closeBottomSheet);
-  sheetOverlay.addEventListener('click', closeBottomSheet);
+  // オーバーレイのクリック座標にエンティティがあればポップアップを切り替え、
+  // なければシートを閉じる
+  sheetOverlay.addEventListener('click', function(e) {
+    var rect = map.getContainer().getBoundingClientRect();
+    var features = map.queryRenderedFeatures(
+      [e.clientX - rect.left, e.clientY - rect.top],
+      { layers: ['entity-points', 'entity-labels'] }
+    );
+    if (features.length > 0) {
+      openPopupForEntity(features[0].properties.id);
+    } else {
+      closeBottomSheet();
+    }
+  });
 
   function openBottomSheet(header, body) {
     sheetHeader.innerHTML = '';


### PR DESCRIPTION
## Summary
- ボトムシート表示中に別のエンティティをタップすると、シートが閉じるだけで新しいポップアップが開かない問題を修正。オーバーレイのクリック時に `queryRenderedFeatures` でエンティティの有無を判定するようにした
- 選択したエンティティが重なった他のエンティティの下に隠れる問題を修正。`circle-sort-key` / `symbol-sort-key` で選択中のエンティティを常に最前面に描画するようにした

## Test plan
- [ ] エンティティAをタップ → ボトムシートが開く
- [ ] その状態でエンティティBをタップ → ボトムシートがBの内容に切り替わる
- [ ] その状態でエンティティ以外の地図をタップ → ボトムシートが閉じる
- [ ] ボトムシートの×ボタン → シートが閉じる
- [ ] ラベルテキストでも同様に切り替えが動作する
- [ ] 重なったエンティティをタップ → 選択したエンティティが最前面に表示される
- [ ] 別のエンティティに切り替え → 前の選択が背面に戻り、新しい選択が最前面になる