### PR TITLE
feat: 100件ずつ自動ダウンロード＋件数プログレスバー表示

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,10 @@
   </div>
 
   <div class="toast" id="toast"></div>
-  <div class="entity-count" id="entity-count"></div>
+  <div class="entity-count" id="entity-count">
+    <div class="entity-count-bar" id="entity-count-bar"></div>
+    <div class="entity-count-text" id="entity-count-text"></div>
+  </div>
 
   <!-- ボトムシート（エンティティ詳細） -->
   <div class="bottom-sheet" id="bottom-sheet">

--- a/src/app.js
+++ b/src/app.js
@@ -295,12 +295,9 @@ function loadNextPage() {
     });
 }
 
-/** 残りページを順次自動取得する（100件ずつ）。完了後に地図のビューを再調整。 */
+/** 残りページを順次自動取得する（100件ずつ）。地図のフィットは初期表示時のみで、追加分では再ズームしない。 */
 function autoLoadAllPages() {
-  if (!hasMore) {
-    fitBoundsToEntities();
-    return Promise.resolve();
-  }
+  if (!hasMore) return Promise.resolve();
   return loadNextPage().then(autoLoadAllPages);
 }
 

--- a/src/app.js
+++ b/src/app.js
@@ -214,20 +214,29 @@ function fetchTemporalEntities(type) {
 // ============================================================
 // GeonicDB はデフォルトで最大 1,000 件を返す。それ以上のデータがある場合は
 // offset パラメータで次のページを取得する。
-// サイドバーのスクロールをトリガーに追加ページを取得し、地図とフィードの
-// 表示件数を常に一致させる。
+// 初期表示後に 100 件ずつ自動で順次取得し、画面下のプログレスバーで進捗を示す。
 
 var PAGE_SIZE = 100;
 var hasMore = true;
 var paginationOffset = 0; // ページネーション専用の offset（WebSocket 追加分を含まない）
 var totalCount = null;
 var entityCountEl = document.getElementById('entity-count');
+var entityCountTextEl = document.getElementById('entity-count-text');
+var entityCountBarEl = document.getElementById('entity-count-bar');
 
-/** 画面下部の件数インジケーターを更新する */
+/** 画面下部の件数インジケーター（プログレスバー）を更新する */
 function updateEntityCount() {
-  if (!entityCountEl || totalCount === null) return;
-  entityCountEl.textContent = entities.length + ' / ' + totalCount;
+  if (!entityCountEl) return;
+  if (totalCount === null) {
+    entityCountTextEl.textContent = entities.length + '';
+    entityCountBarEl.style.width = '0%';
+  } else {
+    entityCountTextEl.textContent = entities.length + ' / ' + totalCount;
+    var pct = totalCount > 0 ? Math.min(100, (entities.length / totalCount) * 100) : 100;
+    entityCountBarEl.style.width = pct + '%';
+  }
   entityCountEl.classList.add('visible');
+  if (!hasMore) entityCountEl.classList.add('done');
 }
 
 
@@ -267,7 +276,6 @@ function fetchEntitiesPage(type, offset, limit) {
 
 /**
  * 次のページを API から取得し、entities 配列・地図・フィードを更新する。
- * サイドバーの無限スクロールから呼ばれるコールバック。
  */
 function loadNextPage() {
   if (!hasMore) return Promise.resolve();
@@ -284,9 +292,16 @@ function loadNextPage() {
       appendFeedItems(result);
       updateEntityCount();
       if (mapApi.isMapReady()) mapApi.renderEntities(entities);
-      // 追加分を含めて地図のビューを自動調整
-      fitBoundsToEntities();
     });
+}
+
+/** 残りページを順次自動取得する（100件ずつ）。完了後に地図のビューを再調整。 */
+function autoLoadAllPages() {
+  if (!hasMore) {
+    fitBoundsToEntities();
+    return Promise.resolve();
+  }
+  return loadNextPage().then(autoLoadAllPages);
 }
 
 // ローディングインジケーター
@@ -331,7 +346,7 @@ dataPromise && dataPromise
       );
       return;
     }
-    initFeed(feedDeps, loadNextPage);
+    initFeed(feedDeps);
     appendFeedItems(entities);
     updateEntityCount();
     db.count({ type: ENTITY_TYPE }).then(function(count) {
@@ -344,6 +359,8 @@ dataPromise && dataPromise
     db.subscribe({ entityTypes: [ENTITY_TYPE] });
     db.connect();
     fitBoundsToEntities();
+    // 残りのページを 100 件ずつ自動で順次取得する
+    autoLoadAllPages().catch(function(err) { console.error('追加データ取得エラー:', err); });
   })
   .catch(function(err) {
     loadingEl.classList.remove('visible');

--- a/src/feed.js
+++ b/src/feed.js
@@ -8,13 +8,7 @@
 import { getEntityName, findGeoProperty, formatTime, formatDateTime } from './entity.js';
 
 var feedList = null;
-
-// 無限スクロール用の状態
-var feedState = {
-  deps: null,
-  onLoadMore: null,
-  loading: false
-};
+var feedDepsRef = null;
 
 /** feedList 要素を取得（初回呼び出し時にキャッシュ） */
 function getFeedList() {
@@ -87,22 +81,6 @@ function createEntityFeedItem(e, deps) {
   return item;
 }
 
-/** スクロールイベントハンドラ — 底付近で次ページの API 取得をトリガー */
-function onFeedScroll() {
-  var list = getFeedList();
-  if (feedState.loading) return;
-  if (list.scrollTop + list.clientHeight >= list.scrollHeight - 100) {
-    if (feedState.onLoadMore) {
-      feedState.loading = true;
-      feedState.onLoadMore().then(function() {
-        feedState.loading = false;
-      }).catch(function() {
-        feedState.loading = false;
-      });
-    }
-  }
-}
-
 /**
  * WebSocket から受信したエンティティをフィードに追加（最新が上）。
  * @param {object} entity - NGSI-LD エンティティ
@@ -139,23 +117,16 @@ export function addFeedItem(entity, isNew, deps) {
 export function appendFeedItems(newEntities) {
   var list = getFeedList();
   newEntities.forEach(function(e) {
-    list.appendChild(createEntityFeedItem(e, feedState.deps));
+    list.appendChild(createEntityFeedItem(e, feedDepsRef));
   });
 }
 
 /**
  * フィードを初期化する。
  * @param {object} deps - { map, selectEntity, getFlyZoom, openPopupForEntity }
- * @param {Function} onLoadMore - 次ページを取得する関数（Promise を返す）
  */
-export function initFeed(deps, onLoadMore) {
+export function initFeed(deps) {
   var list = getFeedList();
   list.innerHTML = '';
-  list.removeEventListener('scroll', onFeedScroll);
-
-  feedState.deps = deps;
-  feedState.onLoadMore = onLoadMore;
-  feedState.loading = false;
-
-  list.addEventListener('scroll', onFeedScroll);
+  feedDepsRef = deps;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -307,15 +307,30 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
   background: rgba(30,30,30,0.9);
   border: 1px solid rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.7);
-  padding: 4px 10px;
   border-radius: 12px;
   font-size: 11px;
   font-family: 'JetBrains Mono', monospace;
   white-space: nowrap;
   opacity: 0;
   transition: opacity 0.3s;
+  overflow: hidden;
+  min-width: 140px;
 }
 .entity-count.visible { opacity: 1; }
+.entity-count-bar {
+  position: absolute;
+  top: 0; left: 0; bottom: 0;
+  width: 0;
+  background: rgba(76, 175, 80, 0.35);
+  transition: width 0.3s ease-out, opacity 0.4s ease-out;
+}
+.entity-count.done .entity-count-bar { opacity: 0; }
+.entity-count-text {
+  position: relative;
+  text-align: center;
+  padding: 4px 10px;
+  z-index: 1;
+}
 
 /* ── ローディングインジケーター ── */
 .loading-indicator {


### PR DESCRIPTION
## Summary

- サイドバーの無限スクロールでの追加取得をやめ、初期表示後にバックグラウンドで 100 件ずつ順次自動取得するように変更
- 画面下の件数インジケーターをプログレスバーに再構成し、取得進捗（`n / total`）を視覚化（バー色は LIVE 表示と揃えたグリーン）
- 全件取得完了後にバーをフェードアウトし件数表示のみ残す

## 変更ファイル

- `src/feed.js` — 無限スクロールハンドラ削除、`initFeed` から `onLoadMore` 引数を撤去
- `src/app.js` — `autoLoadAllPages()` を追加して `loadNextPage()` を再帰呼び出し、`updateEntityCount()` をプログレスバー対応に拡張
- `index.html` — `#entity-count` を `entity-count-bar` ＋ `entity-count-text` の構造に
- `src/style.css` — プログレスバー用スタイル（バー色 `rgba(76, 175, 80, 0.35)`、完了時フェードアウト）

## Test plan

- [x] `npm run build` 通過
- [ ] dev サーバーで件数 > 100 のエンティティタイプを開き、プログレスバーが滑らかに進むこと
- [ ] 全件取得後にバーがフェードアウトし、件数のみ残ること
- [ ] WebSocket 経由の新規エンティティでも件数が増えること
- [ ] Temporal データ取得時（一括取得済み）にバーが即フェードアウトすること

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ページネーションが自動でバックグラウンド読み込みされるようになりました（段階的に全ページを取得）
  * エンティティ数インジケーターに進捗バーを追加し、読み込み進捗と完了状態を視覚化

* **変更**
  * 増分読み込み時に地図の表示領域が再調整されなくなりました（初回ロード時のみ調整）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->