### PR TITLE
fix: 長いエンティティタイプ名がヘッダーのバッジと重ならないようにする

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -696,7 +696,7 @@ body { font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif; back
     top: 8px; left: 8px; right: 8px;
     padding: 12px 12px;
   }
-  .header-type-select { font-size: 13px; position: absolute; left: 50%; transform: translateX(-50%); margin: 0; }
+  .header-type-select { font-size: 13px; position: absolute; left: 50%; transform: translateX(-50%); margin: 0; max-width: calc(100% - 220px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
   .header-sep { display: none; }
 
   .panel-toggle {


### PR DESCRIPTION
## Summary

- モバイル幅で `.header-type-select` が `position: absolute; left: 50%; transform: translateX(-50%)` で中央配置されているため、エンティティタイプ名が長いと左の `LIVE` / `CONNECTING` バッジや右のハンバーガーボタンに重なっていた
- `max-width: calc(100% - 220px)` で幅を制限し、`text-overflow: ellipsis` で省略表示するように修正

## Before / After

Before — `TakamatsuAedLocation` が左端の `LIVE` バッジと重なる:

<img width="300" alt="before" src="https://github.com/user-attachments/assets/PLACEHOLDER" />

After — バッジ・ハンバーガーいずれにも被らず、より長い文字列は `…` で省略:

```
● CONNECTING        TakamatsuAedLocation ▼        ≡
● CONNECTING    VeryLongEntityTypeNameForTe... ▼   ≡
```

## Test plan

- [x] `npm run build` が通ること
- [x] モバイル幅 (innerWidth=500) で `TakamatsuAedLocation` が `CONNECTING` バッジに被らないことをブラウザで確認
- [x] さらに長い文字列で `…` 省略が機能することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * モバイル表示時にヘッダー要素のテキストが長すぎる場合の表示崩れを修正しました。テキストが自動的に切り詰められ、省略記号で表示されるようになり、レイアウト問題が解決されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->