### PR TITLE
chore: @geolonia/geonicdb-sdk を 0.4.0 にアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.3.0"
+        "@geolonia/geonicdb-sdk": "^0.4.0"
       },
       "devDependencies": {
         "vite": "^8.0.1",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.3.0.tgz",
-      "integrity": "sha512-xrma2ELyZ3bFLzSvLP+YS6y7vExScIY7jTj56A7xgCSJPZDaB4z/JpLoOOYkZFpR95C4zdFwcZe40IiHky0ydA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.4.0.tgz",
+      "integrity": "sha512-StR6Ed6D0Uzy9OArTOInu/bktmVQfnaX9Ql57kwEeCHfQC1yDscvYZz7LK8AEZN2yrs54jGF/VvSUkvXtVKdHQ==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.3.0"
+    "@geolonia/geonicdb-sdk": "^0.4.0"
   }
 }


### PR DESCRIPTION
## Summary

`@geolonia/geonicdb-sdk` を `^0.3.0` → `^0.4.0` にアップデート。

### v0.4.0 で追加された機能

- **クライアントキャッシュ Phase A** — in-memory cache + ETag/304 自動ハンドリング + リクエスト重複排除 + ETag ベース `poll()` API
  - GET / HEAD リクエストに `If-None-Match` / `If-Modified-Since` を自動付与、304 受信時はキャッシュから即返却
  - 同一 path への in-flight 重複リクエストを 1 つにまとめる dedup
  - WebSocket の `entityCreated` / `entityUpdated` / `entityDeleted` 受信時にキャッシュを自動無効化
  - 認証コンテキスト切替（login / setCredentials / logout）時に cache を自動破棄
- 既存 API は完全に後方互換維持 — pulse のコード変更は不要、透過的に cache の恩恵を受けられる

## Test plan

- [x] `npm install @geolonia/geonicdb-sdk@^0.4.0` 完了
- [x] `npm run build` 成功


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 基盤となるSDKを最新バージョンに更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->