### PR TITLE
chore: @geolonia/geonicdb-sdk を 0.5.0 にアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.4.0"
+        "@geolonia/geonicdb-sdk": "^0.5.0"
       },
       "devDependencies": {
         "vite": "^8.0.1",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.4.0.tgz",
-      "integrity": "sha512-StR6Ed6D0Uzy9OArTOInu/bktmVQfnaX9Ql57kwEeCHfQC1yDscvYZz7LK8AEZN2yrs54jGF/VvSUkvXtVKdHQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.5.0.tgz",
+      "integrity": "sha512-LVTlWsc6IHHLKQ2CWsZSHsplPG33OjjE0T2cv5EqNZWaausbNpMEsk+WfXfnsoEBGnJYh03zYmwmvbyjj0ubig==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.4.0"
+    "@geolonia/geonicdb-sdk": "^0.5.0"
   }
 }


### PR DESCRIPTION
## Summary

`@geolonia/geonicdb-sdk` を `^0.4.0` → `^0.5.0` に更新。

## 含まれる変更

- **WebSocket entity event での自動キャッシュ無効化を削除** (geolonia/geonicdb#1060)
  - 旧 SDK は `entityCreated` / `entityUpdated` / `entityDeleted` 受信時に全 entities cache エントリを削除していた
  - 削除すると ETag も失われ、毎回 full 200 が走り 304 帯域節約パスが死んでいた
  - 新 SDK は cache を残し、サーバ側 ETag マッチで 304 / 200 を自動振り分け
  - **pulse の体感**: WebSocket 受信中も unchanged data の再取得が 304 (~200 bytes) で完了

## 検証

- [x] `npm install` — OK
- [x] `npm run build` — OK (Vite, 392ms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **依存関係の更新**
  * 内部の地理情報ライブラリを最新版にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->