### PR TITLE
chore(deps): bump @geolonia/geonicdb-sdk to ^0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.5.0"
+        "@geolonia/geonicdb-sdk": "^0.6.0"
       },
       "devDependencies": {
         "vite": "^8.0.1",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.5.0.tgz",
-      "integrity": "sha512-LVTlWsc6IHHLKQ2CWsZSHsplPG33OjjE0T2cv5EqNZWaausbNpMEsk+WfXfnsoEBGnJYh03zYmwmvbyjj0ubig==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.6.0.tgz",
+      "integrity": "sha512-VVpKgYheVguatbfn+zP20QyshSmsXl4JrXMoWWRu3ylaDte/ZZ6cLcSLpy1/enzYle/3qRUiEnd2V6JN11ezew==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.5.0"
+    "@geolonia/geonicdb-sdk": "^0.6.0"
   }
 }


### PR DESCRIPTION
## Summary

- `@geolonia/geonicdb-sdk` を `^0.5.0` → `^0.6.0` にアップデート
- v0.6.0 で `anonymous` モード等の新機能が追加されたが、本サンプルアプリの既存実装は API 互換のため変更なし
- `npm run build` で動作確認済み

## v0.6.0 highlights ([CHANGELOG](https://github.com/geolonia/geonicdb/blob/main/CHANGELOG.md))

- **SDK** anonymous モード追加 (#1105)
- **ReactiveCore Rules** `eventType` 条件 (CREATE/UPDATE/DELETE フィルタ) (#1103)
- **ReactiveCore Rules** CEL に `previous.attribute` 露出 (#1106)
- **認可** WebSocket 配信時の XACML AuthzRequest に `entityOwner` を inject (#1107)
- **認可** NGSI-LD Subscription POST PIP で購読対象属性を inject (#1104)
- **Breaking** WebSocket 認証から `?token=` URL クエリを廃止 (#1072) — このサンプルでは Authorization ヘッダ経由なので影響なし

## Test plan

- [x] `npm install`
- [x] `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Geonicdb SDK パッケージを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->