### PR TITLE
chore(deps): bump @geolonia/geonicdb-sdk to ^0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.6.0"
+        "@geolonia/geonicdb-sdk": "^0.7.0"
       },
       "devDependencies": {
         "vite": "^8.0.1",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.6.0.tgz",
-      "integrity": "sha512-VVpKgYheVguatbfn+zP20QyshSmsXl4JrXMoWWRu3ylaDte/ZZ6cLcSLpy1/enzYle/3qRUiEnd2V6JN11ezew==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.7.0.tgz",
+      "integrity": "sha512-dxYIP9JSnKvsp479pcaSdDWiV3YF2xLWovAydwOxwgeDXSlhpTYGlKFBmKsCXJnf8E6Z3jpv76z/1X1jsbEF0w==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.6.0"
+    "@geolonia/geonicdb-sdk": "^0.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- `@geolonia/geonicdb-sdk` を `^0.6.0` → `^0.7.0` に bump
- 本体 `geolonia/geonicdb` v0.7.0 リリース ([geolonia/geonicdb#1126](https://github.com/geolonia/geonicdb/pull/1126)) に追従

## v0.7.0 で取り込まれる主な改善
- **fix(sdk)**: 公開 d.ts (`geonicdb.d.ts`) からエラークラス (`GeonicDBError` / `AuthenticationError` / `AuthorizationError` 等) が落ちていた問題を修正
- **feat(sdk)**: `anonymous` モード — token 取得・`Authorization` ヘッダ送信を完全スキップして公開リソースを取得可能に

## Test plan
- [x] `npm install` — 成功
- [x] `npm run build` — 成功 (vite v8.0.1, 291ms)
- [ ] 動作確認 (devサーバーで認証・WS が動くこと)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * @geolonia/geonicdb-sdk の依存関係を v0.6.0 から v0.7.0 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->