### PR TITLE
chore(deps): bump @geolonia/geonicdb-sdk to ^0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.7.0"
+        "@geolonia/geonicdb-sdk": "^0.7.1"
       },
       "devDependencies": {
         "vite": "^8.0.1",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.7.0.tgz",
-      "integrity": "sha512-dxYIP9JSnKvsp479pcaSdDWiV3YF2xLWovAydwOxwgeDXSlhpTYGlKFBmKsCXJnf8E6Z3jpv76z/1X1jsbEF0w==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.7.1.tgz",
+      "integrity": "sha512-VuU86xbz68pAPKb4yjCi62vhUc6ieGqZPT3yQ528IMkd+ixdfE7pPQJPZ7sYKJrOOtnzfjii2AVNX3NWaqVtYQ==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.7.0"
+    "@geolonia/geonicdb-sdk": "^0.7.1"
   }
 }


### PR DESCRIPTION
v0.7.1 で SDK 公開 d.ts の strict tsconfig 対応 (geolonia/geonicdb#1127 / #1128) が反映。pulse は JS なので直接的影響はないが、最新版に追従。

- package.json / package-lock.json: `@geolonia/geonicdb-sdk` `^0.7.0` → `^0.7.1`
- `npm run build` 通過確認済 (vite cache を一度 clear する必要あり)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Geolonia GeonicDB SDK の依存ライブラリをバージョン 0.7.1 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->