### PR TITLE
エンティティタイプ切替を in-place 化（地図のちらつき・東京ジャンプを解消）

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -94,7 +94,10 @@ if (ENTITY_TYPE !== '__none__') {
   .catch(function() {});
 
   appTypeSelect.addEventListener('change', function() {
-    location.href = '?type=' + encodeURIComponent(appTypeSelect.value);
+    // フルリロードせず in-place で type を切替える（地図はそのまま、データだけ入れ替え）
+    var newType = appTypeSelect.value;
+    history.replaceState(null, '', '?type=' + encodeURIComponent(newType));
+    loadType(newType);
   });
 }
 
@@ -276,11 +279,14 @@ function fetchEntitiesPage(type, offset, limit) {
 
 /**
  * 次のページを API から取得し、entities 配列・地図・フィードを更新する。
+ * 取得開始時の type を覚えておき、途中で別 type に切替えられたら結果は破棄する。
  */
 function loadNextPage() {
   if (!hasMore) return Promise.resolve();
-  return fetchEntitiesPage(ENTITY_TYPE, paginationOffset, PAGE_SIZE)
+  var thisType = ENTITY_TYPE;
+  return fetchEntitiesPage(thisType, paginationOffset, PAGE_SIZE)
     .then(function(result) {
+      if (ENTITY_TYPE !== thisType) return;
       if (!Array.isArray(result) || result.length === 0) {
         hasMore = false;
         return;
@@ -298,34 +304,65 @@ function loadNextPage() {
 /** 残りページを順次自動取得する（100件ずつ）。地図のフィットは初期表示時のみで、追加分では再ズームしない。 */
 function autoLoadAllPages() {
   if (!hasMore) return Promise.resolve();
-  return loadNextPage().then(autoLoadAllPages);
+  var thisType = ENTITY_TYPE;
+  return loadNextPage().then(function() {
+    if (ENTITY_TYPE !== thisType) return;
+    return autoLoadAllPages();
+  });
 }
 
 // ローディングインジケーター
 var loadingEl = document.getElementById('loading-indicator');
-if (ENTITY_TYPE !== '__none__') loadingEl.classList.add('visible');
 
-// まず Temporal API を試し、時系列データがあればそれを使う。
-// なければ通常の NGSI-LD entities API にページネーションでフォールバックする。
-var dataPromise = (ENTITY_TYPE !== '__none__')
-  ? fetchTemporalEntities(ENTITY_TYPE).then(function(result) {
-      if (result.length > 0) {
-        TEMPORAL = true;
-        ctx.TEMPORAL = true;
-        document.title = ENTITY_TYPE + ' (Temporal) — GeonicDB Pulse';
-        // Temporal データはページネーション対象外（一括取得済み）
-        hasMore = false;
-        return result;
-      }
-      // Temporal データがなければ通常 API の最初のページを取得
-      return fetchEntitiesPage(ENTITY_TYPE, 0, PAGE_SIZE);
-    }).catch(function() {
-      return fetchEntitiesPage(ENTITY_TYPE, 0, PAGE_SIZE);
-    })
-  : null;
+/**
+ * 指定タイプのデータをロードして UI に反映する。
+ * 初回ロード時とプルダウン切替時の両方から呼ばれる（後者は地図は維持したままデータだけ入れ替え）。
+ */
+function loadType(newType) {
+  ENTITY_TYPE = newType;
 
-dataPromise && dataPromise
-  .then(function(result) {
+  // 状態リセット
+  document.title = newType + ' — GeonicDB Pulse';
+  TEMPORAL = false;
+  ctx.TEMPORAL = false;
+  entities.length = 0;
+  Object.keys(temporalRaw).forEach(function(k) { delete temporalRaw[k]; });
+  paginationOffset = 0;
+  hasMore = true;
+  totalCount = null;
+
+  // UI リセット（前回 showError で隠していたヘッダー/サイドパネルを復帰）
+  document.getElementById('error-overlay').classList.add('hidden');
+  document.querySelector('.header').style.display = '';
+  document.querySelector('.side-panel').style.display = '';
+  initFeed(feedDeps);
+  if (mapApi.isMapReady()) mapApi.renderEntities([]);
+  if (entityCountEl) {
+    entityCountEl.classList.remove('visible');
+    entityCountEl.classList.remove('done');
+  }
+  loadingEl.classList.add('visible');
+
+  // まず Temporal API を試し、時系列データがあればそれを使う。
+  // なければ通常の NGSI-LD entities API にページネーションでフォールバックする。
+  var dataPromise = fetchTemporalEntities(newType).then(function(result) {
+    if (result.length > 0) {
+      TEMPORAL = true;
+      ctx.TEMPORAL = true;
+      document.title = newType + ' (Temporal) — GeonicDB Pulse';
+      // Temporal データはページネーション対象外（一括取得済み）
+      hasMore = false;
+      return result;
+    }
+    // Temporal データがなければ通常 API の最初のページを取得
+    return fetchEntitiesPage(newType, 0, PAGE_SIZE);
+  }).catch(function() {
+    return fetchEntitiesPage(newType, 0, PAGE_SIZE);
+  });
+
+  dataPromise.then(function(result) {
+    // 切替中に別タイプへ再切替された場合は古いレスポンスを破棄
+    if (ENTITY_TYPE !== newType) return;
     loadingEl.classList.remove('visible');
     if (!Array.isArray(result)) result = [];
     sortByCreatedAt(result);
@@ -338,28 +375,29 @@ dataPromise && dataPromise
 
     if (entities.length === 0) {
       mapApi.showError(
-        '"' + ENTITY_TYPE + '" が見つかりません',
+        '"' + newType + '" が見つかりません',
         'このエンティティタイプのデータが存在しないか、タイプ名が正しくありません。'
       );
       return;
     }
-    initFeed(feedDeps);
     appendFeedItems(entities);
     updateEntityCount();
-    db.count({ type: ENTITY_TYPE }).then(function(count) {
+    db.count({ type: newType }).then(function(count) {
+      if (ENTITY_TYPE !== newType) return;
       totalCount = count;
       updateEntityCount();
     }).catch(function() {});
     if (mapApi.isMapReady()) { mapApi.renderEntities(entities); }
     else { mapApi.setPendingRender(entities); }
-    // 初期データ取得完了後に WebSocket 接続を開始し、REST スナップショットとの競合を防ぐ
-    db.subscribe({ entityTypes: [ENTITY_TYPE] });
-    db.connect();
+    // 初期データ取得完了後に WebSocket を接続/再購読する（subscribe は再呼出で購読を置き換える）
+    db.subscribe({ entityTypes: [newType] });
+    if (!db.isConnected()) db.connect();
     fitBoundsToEntities();
     // 残りのページを 100 件ずつ自動で順次取得する
     autoLoadAllPages().catch(function(err) { console.error('追加データ取得エラー:', err); });
   })
   .catch(function(err) {
+    if (ENTITY_TYPE !== newType) return;
     loadingEl.classList.remove('visible');
     console.error('データ取得エラー:', err);
     if (isAuthError(err)) {
@@ -372,6 +410,10 @@ dataPromise && dataPromise
       err.message || '接続エラーが発生しました。API キーやテナント設定を確認してください。'
     );
   });
+}
+
+// 初回ロード（type が指定されていればその type をロード）
+if (ENTITY_TYPE !== '__none__') loadType(ENTITY_TYPE);
 
 // ============================================================
 // WebSocket リアルタイム更新

--- a/src/app.js
+++ b/src/app.js
@@ -361,6 +361,8 @@ function loadType(newType) {
   // まず Temporal API を試し、時系列データがあればそれを使う。
   // なければ通常の NGSI-LD entities API にページネーションでフォールバックする。
   var dataPromise = fetchTemporalEntities(newType).then(function(result) {
+    // 解決時点で別タイプに切替わっていれば、無駄な fallback fetch を回避して即中断
+    if (ENTITY_TYPE !== newType) return [];
     if (result.length > 0) {
       TEMPORAL = true;
       ctx.TEMPORAL = true;
@@ -372,6 +374,7 @@ function loadType(newType) {
     // Temporal データがなければ通常 API の最初のページを取得
     return fetchEntitiesPage(newType, 0, PAGE_SIZE);
   }).catch(function() {
+    if (ENTITY_TYPE !== newType) return [];
     return fetchEntitiesPage(newType, 0, PAGE_SIZE);
   });
 

--- a/src/app.js
+++ b/src/app.js
@@ -402,6 +402,11 @@ function loadType(newType) {
     result.forEach(function(e) { entities.push(e); });
     paginationOffset = result.length;
 
+    // 空タイプでも WebSocket 購読は新タイプに切替える（あとで新規作成された
+    // エンティティが届くようにするため、エラー表示時も含めて必ず subscribe する）
+    db.subscribe({ entityTypes: [newType] });
+    if (!db.isConnected()) db.connect();
+
     if (entities.length === 0) {
       mapApi.showError(
         '"' + newType + '" が見つかりません',
@@ -418,9 +423,6 @@ function loadType(newType) {
     }).catch(function() {});
     if (mapApi.isMapReady()) { mapApi.renderEntities(entities); }
     else { mapApi.setPendingRender(entities); }
-    // 初期データ取得完了後に WebSocket を接続/再購読する（subscribe は再呼出で購読を置き換える）
-    db.subscribe({ entityTypes: [newType] });
-    if (!db.isConnected()) db.connect();
     fitBoundsToEntities();
     // 残りのページを 100 件ずつ自動で順次取得する
     autoLoadAllPages().catch(function(err) { console.error('追加データ取得エラー:', err); });

--- a/src/app.js
+++ b/src/app.js
@@ -373,7 +373,8 @@ function loadType(newType) {
     }
     // Temporal データがなければ通常 API の最初のページを取得
     return fetchEntitiesPage(newType, 0, PAGE_SIZE);
-  }).catch(function() {
+  }).catch(function(err) {
+    console.warn('Temporal API 取得エラー、通常 entities API にフォールバックします:', err);
     if (ENTITY_TYPE !== newType) return [];
     return fetchEntitiesPage(newType, 0, PAGE_SIZE);
   });

--- a/src/app.js
+++ b/src/app.js
@@ -111,6 +111,9 @@ if (ENTITY_TYPE === '__none__') {
 // ============================================================
 var entities = [];       // 現在のエンティティ一覧（REST API + WebSocket で更新）
 var temporalRaw = {};    // Temporal API の生レスポンスを保持（ポップアップのスパークライン表示用）
+// loadType 呼び出しごとに増えるトークン。A→B→A のような切替で、最初の A の遅延
+// レスポンスが二回目の A のロードに混ざらないよう、type 一致だけでなくトークン一致も検査する。
+var activeLoadToken = 0;
 
 // 地図の初期化（entities/temporalRaw/TEMPORAL への参照を渡す）
 var ctx = { entities: entities, temporalRaw: temporalRaw, TEMPORAL: TEMPORAL };
@@ -179,7 +182,9 @@ function fetchTemporalEntities(type) {
   // 共有 temporalRaw への書き込みは Promise 解決時にまとめて行う。
   // 解決時点で type が切替わっていればローカル結果ごと破棄して、古いレスポンスが
   // 共有 state を再汚染しないようにする。
+  // A→B→A の素早い切替対策として、type 一致だけでなく activeLoadToken の一致も検査する。
   var localTemporalRaw = {};
+  var thisLoadToken = activeLoadToken;
 
   // db.request() はパース済み JSON を直接返す（Response オブジェクトではない）
   var temporalPromise = db.request('GET', '/ngsi-ld/v1/temporal/entities?type=' + encodeURIComponent(type) + '&limit=1000')
@@ -194,8 +199,8 @@ function fetchTemporalEntities(type) {
 
   return Promise.all([temporalPromise, entitiesPromise])
     .then(function(results) {
-      // 解決した時点で別タイプに切替わっていれば、共有 state には反映せず空を返す
-      if (ENTITY_TYPE !== type) return [];
+      // 解決した時点で別タイプ／別 load に切替わっていれば、共有 state には反映せず空を返す
+      if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== type) return [];
 
       var rawEntities = results[0];
       var currentEntities = results[1];
@@ -295,9 +300,10 @@ function fetchEntitiesPage(type, offset, limit) {
 function loadNextPage() {
   if (!hasMore) return Promise.resolve();
   var thisType = ENTITY_TYPE;
+  var thisLoadToken = activeLoadToken;
   return fetchEntitiesPage(thisType, paginationOffset, PAGE_SIZE)
     .then(function(result) {
-      if (ENTITY_TYPE !== thisType) return;
+      if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== thisType) return;
       if (!Array.isArray(result) || result.length === 0) {
         hasMore = false;
         return;
@@ -316,8 +322,9 @@ function loadNextPage() {
 function autoLoadAllPages() {
   if (!hasMore) return Promise.resolve();
   var thisType = ENTITY_TYPE;
+  var thisLoadToken = activeLoadToken;
   return loadNextPage().then(function() {
-    if (ENTITY_TYPE !== thisType) return;
+    if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== thisType) return;
     return autoLoadAllPages();
   });
 }
@@ -331,6 +338,9 @@ var loadingEl = document.getElementById('loading-indicator');
  */
 function loadType(newType) {
   ENTITY_TYPE = newType;
+  // この loadType に紐づくトークンを発行。以降の async continuation はこのトークン
+  // と activeLoadToken の一致でも判定する（A→B→A race を防ぐ）
+  var thisLoadToken = ++activeLoadToken;
 
   // 状態リセット
   document.title = newType + ' — GeonicDB Pulse';
@@ -361,8 +371,8 @@ function loadType(newType) {
   // まず Temporal API を試し、時系列データがあればそれを使う。
   // なければ通常の NGSI-LD entities API にページネーションでフォールバックする。
   var dataPromise = fetchTemporalEntities(newType).then(function(result) {
-    // 解決時点で別タイプに切替わっていれば、無駄な fallback fetch を回避して即中断
-    if (ENTITY_TYPE !== newType) return [];
+    // 解決時点で別タイプ／別 load に切替わっていれば、無駄な fallback fetch を回避して即中断
+    if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== newType) return [];
     if (result.length > 0) {
       TEMPORAL = true;
       ctx.TEMPORAL = true;
@@ -375,13 +385,13 @@ function loadType(newType) {
     return fetchEntitiesPage(newType, 0, PAGE_SIZE);
   }).catch(function(err) {
     console.warn('Temporal API 取得エラー、通常 entities API にフォールバックします:', err);
-    if (ENTITY_TYPE !== newType) return [];
+    if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== newType) return [];
     return fetchEntitiesPage(newType, 0, PAGE_SIZE);
   });
 
   dataPromise.then(function(result) {
-    // 切替中に別タイプへ再切替された場合は古いレスポンスを破棄
-    if (ENTITY_TYPE !== newType) return;
+    // 切替中に別タイプ／別 load へ再切替された場合は古いレスポンスを破棄
+    if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== newType) return;
     loadingEl.classList.remove('visible');
     if (!Array.isArray(result)) result = [];
     sortByCreatedAt(result);
@@ -402,7 +412,7 @@ function loadType(newType) {
     appendFeedItems(entities);
     updateEntityCount();
     db.count({ type: newType }).then(function(count) {
-      if (ENTITY_TYPE !== newType) return;
+      if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== newType) return;
       totalCount = count;
       updateEntityCount();
     }).catch(function() {});
@@ -416,7 +426,7 @@ function loadType(newType) {
     autoLoadAllPages().catch(function(err) { console.error('追加データ取得エラー:', err); });
   })
   .catch(function(err) {
-    if (ENTITY_TYPE !== newType) return;
+    if (activeLoadToken !== thisLoadToken || ENTITY_TYPE !== newType) return;
     loadingEl.classList.remove('visible');
     console.error('データ取得エラー:', err);
     if (isAuthError(err)) {

--- a/src/app.js
+++ b/src/app.js
@@ -176,11 +176,16 @@ document.addEventListener('visibilitychange', function() {
  * 静的属性は通常の entities API から取得してマージする。
  */
 function fetchTemporalEntities(type) {
+  // 共有 temporalRaw への書き込みは Promise 解決時にまとめて行う。
+  // 解決時点で type が切替わっていればローカル結果ごと破棄して、古いレスポンスが
+  // 共有 state を再汚染しないようにする。
+  var localTemporalRaw = {};
+
   // db.request() はパース済み JSON を直接返す（Response オブジェクトではない）
   var temporalPromise = db.request('GET', '/ngsi-ld/v1/temporal/entities?type=' + encodeURIComponent(type) + '&limit=1000')
     .then(function(rawEntities) {
       if (!Array.isArray(rawEntities)) rawEntities = [];
-      rawEntities.forEach(function(te) { temporalRaw[te.id] = te; });
+      rawEntities.forEach(function(te) { localTemporalRaw[te.id] = te; });
       return rawEntities;
     });
 
@@ -189,8 +194,14 @@ function fetchTemporalEntities(type) {
 
   return Promise.all([temporalPromise, entitiesPromise])
     .then(function(results) {
+      // 解決した時点で別タイプに切替わっていれば、共有 state には反映せず空を返す
+      if (ENTITY_TYPE !== type) return [];
+
       var rawEntities = results[0];
       var currentEntities = results[1];
+
+      // ここで初めて共有 temporalRaw に commit する
+      Object.keys(localTemporalRaw).forEach(function(k) { temporalRaw[k] = localTemporalRaw[k]; });
 
       // 通常エンティティを ID でルックアップできるようにする
       var entityMap = {};
@@ -335,6 +346,10 @@ function loadType(newType) {
   document.getElementById('error-overlay').classList.add('hidden');
   document.querySelector('.header').style.display = '';
   document.querySelector('.side-panel').style.display = '';
+  // 旧タイプのエンティティ詳細やマーカーが一瞬残らないよう、開いている詳細 UI を閉じ
+  // 地図ロード前に登録された pendingRender も破棄する
+  mapApi.closeBottomSheet();
+  mapApi.setPendingRender(null);
   initFeed(feedDeps);
   if (mapApi.isMapReady()) mapApi.renderEntities([]);
   if (entityCountEl) {

--- a/src/map.js
+++ b/src/map.js
@@ -28,21 +28,40 @@ var sparkColors = ['#00e5ff', '#76ff03', '#ffab00', '#ff4081', '#7c4dff', '#00e6
 // 地図の初期化
 // ============================================================
 
+// エンティティタイプ切り替え時のページリロードを跨いで地図位置を保持する
+var VIEW_STORAGE_KEY = 'pulse:mapView';
+function loadSavedView() {
+  try {
+    var raw = sessionStorage.getItem(VIEW_STORAGE_KEY);
+    if (!raw) return null;
+    var v = JSON.parse(raw);
+    if (typeof v.lng !== 'number' || typeof v.lat !== 'number' || typeof v.zoom !== 'number') return null;
+    return v;
+  } catch (e) { return null; }
+}
+
 /**
  * 地図を初期化し、操作に必要な関数群を返す。
  * @param {object} ctx - { entities, temporalRaw, TEMPORAL } への参照を持つコンテキスト
  * @returns {object} 地図操作用の関数群
  */
 export function initMap(ctx) {
+  var savedView = loadSavedView();
   map = new geolonia.Map({
     container: 'map',
     style: mapStyle,
-    center: [139.7414, 35.6581],
-    zoom: 10,
+    center: savedView ? [savedView.lng, savedView.lat] : [139.7414, 35.6581],
+    zoom: savedView ? savedView.zoom : 10,
     minZoom: 2,
     maxZoom: 18,
     renderWorldCopies: false,
     pitchWithRotate: false
+  });
+
+  // 地図移動のたびに現在のビューを保存し、エンティティタイプ切り替え後も同じ位置から表示する
+  map.on('moveend', function() {
+    var c = map.getCenter();
+    sessionStorage.setItem(VIEW_STORAGE_KEY, JSON.stringify({ lng: c.lng, lat: c.lat, zoom: map.getZoom() }));
   });
 
   // モバイルではアトリビューションを畳む

--- a/src/map.js
+++ b/src/map.js
@@ -507,6 +507,7 @@ export function initMap(ctx) {
     renderEntities: renderEntities,
     selectEntity: selectEntity,
     openPopupForEntity: openPopupForEntity,
+    closeBottomSheet: closeBottomSheet,
     getFlyZoom: getFlyZoom,
     sidebarPadding: sidebarPadding,
     isMapReady: isMapReady,


### PR DESCRIPTION
## Summary
- ヘッダーのプルダウンで type を切替えるたびにフルリロードしていたため、(1) 地図が一瞬初期座標 (東京) に戻る、(2) 旧画面が一瞬見える、というちらつきが発生していた
- SDK の `subscribe()` は再呼び出しで購読を置き換える設計なので、フルリロードを廃止して **in-place でデータだけ差替える** 方式に変更（地図インスタンスはそのまま維持）
- 直接 URL アクセス時の初期表示でも Tokyo に飛ばないよう、`sessionStorage` に直近の view を保存して復元するようにした

## 変更点
- `src/app.js`
  - ドロップダウンの change イベントで `location.href` ではなく `history.replaceState` + `loadType(newType)` を呼ぶように変更
  - `loadType()` で状態リセット (entities/temporalRaw/pagination 等) → データ再取得 → `mapApi.renderEntities([])` でマップソース空化 → 新データ描画 → `db.subscribe()` で購読切替
  - `loadNextPage` / `autoLoadAllPages` / `db.count` などの非同期処理に「途中で type 変更されたら結果を破棄」する race guard を追加
- `src/map.js`
  - `moveend` ごとに center/zoom を `sessionStorage` (`pulse:mapView`) に保存
  - `initMap()` 起動時に保存値があればそれを初期 view に使用（無ければ従来どおり東京）

## Test plan
- [x] `npm run build` 通過
- [x] ローカル dev サーバーで以下を手動確認:
  - [x] AedLocation → PublicToilet → Cafe と切替しても地図が消えず、データだけが入れ替わる
  - [x] 切替時に LIVE 接続が維持される
  - [x] フィードが新タイプのものに差替わる
  - [x] pagination が継続する (例: 100/169 → 30/30)
  - [x] URL バーは `?type=...` が新タイプに更新される（履歴に残らないよう replaceState）
  - [x] 直接 URL アクセス時、前回の view から地図が始まる（Tokyo に飛ばない）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * マップの中心座標とズームがセッションに保存・復元され、移動終了時に自動で更新されます。

* **改善**
  * エンティティタイプ切替時の読み込みフローを統合し、優先取得→フォールバックの流れで安定化しました。
  * ページネーションと自動読み込みで、古いタイプや競合する読み込み結果を破棄するガードを強化しました。
  * 表示リセット、サブスクリプション/接続制御、初期ロード時のエラーメッセージ挙動を調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->