### PR TITLE
feat: パスワードログインを DPoP 送信者制約セッションに切替 (closes #89)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.7.1"
+        "@geolonia/geonicdb-sdk": "^0.9.0"
       },
       "devDependencies": {
         "vite": "^8.0.1",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.7.1.tgz",
-      "integrity": "sha512-VuU86xbz68pAPKb4yjCi62vhUc6ieGqZPT3yQ528IMkd+ixdfE7pPQJPZ7sYKJrOOtnzfjii2AVNX3NWaqVtYQ==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.9.0.tgz",
+      "integrity": "sha512-sI5rFo/+DsHILJa6UjTXcodvA+pwjhbABK1aWKHNVrIIKoN0FAsr/NBByfZZH2LRghmmbhXjircPxKTs10dt3Q==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.7.1"
+    "@geolonia/geonicdb-sdk": "^0.9.0"
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -2,8 +2,10 @@
  * main.js — エントリポイント
  *
  * 認証フロー:
- *   1. 保存済みトークンがあれば db.setCredentials() で復元
- *   2. なければログインフォームで db.login() を呼び出す
+ *   1. 保存済みトークンが Bearer なら db.setCredentials() で復元
+ *      (DPoP-bound トークンは秘密鍵がページリロードで失われるため復元不可)
+ *   2. なければログインフォームで db.login(..., { dpop: true }) を呼ぶ
+ *      (RFC 9449 DPoP 送信者制約セッション、XSS 漏洩耐性のため)
  *   3. initApp(db, auth) でアプリを起動
  */
 
@@ -53,8 +55,20 @@ function removeLoginForm() {
 // 認証フローを開始
 var auth = getStoredAuth();
 
+// DPoP-bound セッション (RFC 9449) はクライアントの非抽出 ECDSA 秘密鍵に
+// 紐付くトークンを発行する。秘密鍵はメモリ上 (Web Crypto の non-extractable
+// CryptoKey) にしか存在せず、ページリロードで失われる。
+// 残った accessToken / refreshToken も鍵なしでは proof を作れず使用不能
+// なので、潔くクリアしてログイン画面に戻す。これが「鍵を持つセッションだけが
+// 正当」という DPoP の本質に即した挙動。
+if (auth && auth.tokenType === 'DPoP' && auth.accessToken) {
+  clearAuth();
+  auth = getStoredAuth();
+}
+
 if (auth && auth.accessToken && auth.tenant) {
-  // ── 保存済みトークンで復元 ──
+  // ── 保存済み Bearer トークンで復元 ──
+  // (DPoP は上で弾かれているのでここに来るのは Bearer のみ)
   // 環境変数が変更された場合に備え、常に現在の URL を使用する
   auth.url = geonicdbUrl;
 
@@ -105,13 +119,17 @@ if (auth && auth.accessToken && auth.tenant) {
     errorEl.textContent = '';
 
     // SDK の db.login() でログイン
+    // { dpop: true } で /auth/dpop-bind を経由して DPoP 送信者制約セッション
+    // (RFC 9449) に交換する。SDK 0.9.0 以降。トークンが localStorage から
+    // XSS で漏洩しても、SDK インスタンスの非抽出秘密鍵がなければ再利用不可。
     var db = new GeonicDB({ baseUrl: geonicdbUrl, tenant: tenant });
-    db.login(email, password).then(function(data) {
+    db.login(email, password, { dpop: true }).then(function(data) {
       var auth = {
         email: email,
         accessToken: data.accessToken,
         refreshToken: data.refreshToken,
         expiresAt: Date.now() + data.expiresIn * 1000,
+        tokenType: data.tokenType,  // 'DPoP' — 次回ロード時の復元判定に使う
         tenant: tenant,
         url: geonicdbUrl,
       };
@@ -120,6 +138,7 @@ if (auth && auth.accessToken && auth.tenant) {
       // SDK がトークンをリフレッシュした際に localStorage と同期する
       db.on('tokenRefresh', function(creds) {
         auth.accessToken = creds.token;
+        if (creds.tokenType !== undefined) auth.tokenType = creds.tokenType;
         if (creds.refreshToken !== undefined) auth.refreshToken = creds.refreshToken;
         if (creds.expiresIn !== undefined) auth.expiresAt = Date.now() + creds.expiresIn * 1000;
         storeAuth(auth);


### PR DESCRIPTION
Closes #89

## 概要

`@geolonia/geonicdb-sdk` を `^0.7.1` → `^0.9.0` に bump し、ログイン時に `db.login(email, password, { dpop: true })` で `/auth/dpop-bind` 経由の DPoP 送信者制約セッション (RFC 9449) に切替える。

## 背景

pulse は `src/main.js:118` で accessToken / refreshToken を localStorage に保存しているため、XSS でトークンが漏洩する典型的アンチパターンに該当していた。SDK 0.9.0 (geolonia/geonicdb#1224, closes geolonia/geonicdb#1221) で `{ dpop: true }` opt-in が追加されたため、サンプルアプリとして率先して切替える。

DPoP-bound トークンは SDK インスタンスの非抽出 ECDSA P-256 秘密鍵に紐付くため、localStorage から漏洩しても他クライアント・他オリジンから再利用できない。

## 設計判断

### サンプルとしての明快さ最優先

`CLAUDE.md` の方針に従い、SDK 呼び出しがコード上で直接見える形を維持:

```js
db.login(email, password, { dpop: true }).then(function(data) {
  // data.tokenType === 'DPoP'
  // ...
});
```

### 復元時の DPoP 鍵問題

DPoP 秘密鍵はメモリ常駐 (non-extractable CryptoKey) のためページリロードで失われる。残った accessToken / refreshToken も鍵なしでは proof を作れず使用不能になるため、`auth.tokenType === 'DPoP'` を検出したら潔く `clearAuth()` してログイン画面に戻す。

これは DPoP の本質 ―「鍵を持つセッションだけが正当」― を素直に表現する設計。`@geolonia/geonicdb-sdk` の README にも「fail-closed」が明記されている。

将来 IndexedDB に DPoP 鍵を保存する仕組みが SDK 側に追加されればリロード持続も可能になるが、現状の SDK 0.9.0 にはそのフックがない (#1221 本文の "geonicdb-console 側で後着手" 言及参照)。

### 旧データ互換

既存ユーザーの localStorage に `tokenType` フィールドなし (undefined) → 従来通り Bearer 復元、次回ログインから DPoP に切替。マイグレーション不要。

## 変更点

- `package.json`: `@geolonia/geonicdb-sdk` を `^0.7.1` → `^0.9.0`
- `package-lock.json`: 同期
- `src/main.js`:
  - 復元時に `auth.tokenType === 'DPoP'` を検出したら `clearAuth()` してログイン画面に
  - ログイン時に `{ dpop: true }` を渡す
  - `auth.tokenType = data.tokenType` を保存 (次回復元判定に使う)
  - tokenRefresh コールバックでも tokenType を同期

## Test plan

- [x] `npm install` で `@geolonia/geonicdb-sdk@0.9.0` がインストールされる
- [x] `npm run build` が成功 (16 modules, 99.96 kB → 21.16 kB gzip)
- [ ] **実機 (https://geonicdb.geolonia.com)** でログイン後、Network タブで `POST /auth/dpop-bind` が走り `tokenType: "DPoP"` が返ることを確認
- [ ] 以降の API 呼び出し (`GET /ngsi-ld/v1/entities` 等) が `Authorization: DPoP <token>` + `DPoP: <proof>` ヘッダー付きで成功する
- [ ] WebSocket 接続 (`/streaming`) が DPoP bind で開く
- [ ] ページリロードでログイン画面に戻る (DPoP 秘密鍵が失われるため、これが正しい挙動)
- [ ] localStorage に古い Bearer トークンが残っている既存ユーザーは従来通り Bearer で復元、次回ログインから DPoP に切替

## 関連

- SDK 実装 PR: geolonia/geonicdb#1224 (closes geolonia/geonicdb#1221)
- 本体 `/auth/dpop-bind`: geolonia/geonicdb#1200 (RFC 9449)
- SDK バージョン: `@geolonia/geonicdb-sdk@0.9.0` (npm 公開: 2026-06-10)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * DPoP認証トークンの処理を改善し、復元できないトークンについてはログイン画面に戻るようにしました
  * 認証フローを最適化し、トークンリフレッシュ時の情報更新を強化しました

* **依存関係更新**
  * 認証ライブラリを最新バージョンに更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->