### PR TITLE
クラスタクリック時のズームインを改善 (duration + sidebar padding)

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -363,13 +363,21 @@ export function initMap(ctx) {
         }
       });
 
-      // クラスタをクリックしたらズームイン
+      // クラスタをクリックしたら、そのクラスタが分解されるズームレベルまでズームインする
+      // Supercluster の getClusterExpansionZoom() が「このクラスタが解ける最小のズーム」を返す
+      // 参考: https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/
       map.on('click', 'entity-clusters', function(e) {
         var features = map.queryRenderedFeatures(e.point, { layers: ['entity-clusters'] });
         var clusterId = features[0].properties.cluster_id;
+        var coords = features[0].geometry.coordinates;
         map.getSource('entities').getClusterExpansionZoom(clusterId, function(err, zoom) {
           if (err) return;
-          map.easeTo({ center: features[0].geometry.coordinates, zoom: zoom });
+          map.easeTo({
+            center: coords,
+            zoom: zoom,
+            duration: 500,
+            padding: { bottom: 0, left: sidebarPadding() }
+          });
         });
       });
       map.on('mouseenter', 'entity-clusters', function() { map.getCanvas().style.cursor = 'pointer'; });


### PR DESCRIPTION
## Summary

- クラスタをクリックしたときの `easeTo` に `duration: 500ms` を明示してアニメーションを滑らかに
- `padding.left` で `sidebarPadding()` を渡し、サイドバーが開いていてもクラスタが見える領域の中央に来るようにした
- 参考リンク (MapLibre 公式 example) と意図のコメントを追記

参考: https://maplibre.org/maplibre-gl-js/docs/examples/create-and-style-clusters/

## Test plan

- [x] AED エンティティで「11」のクラスタをクリック → ズーム 11.5 → 12 にズームインし、「9」「3」「2」「4」等のサブクラスタに分解されることを確認
- [x] さらに「9」のクラスタをクリック → ズーム 13 にズームインし、ほぼ個別ポイントに展開
- [x] サイドバーが開いた状態でクリック時、クラスタが画面中央ではなくサイドバー右側の見える領域の中央に来ることを目視確認
- [x] `npm run build` 成功

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* マップのクラスタークリック時のズーム遷移が改善されました。ズーム時の中心座標がより正確に反映され、画面要素の配置（下部および左側パディング）に対応するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->