### PR TITLE
GeonicDB SDK を 0.11.0 に更新し、サンプルとして SDK の使い方を明確化

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.10.0"
+        "@geolonia/geonicdb-sdk": "^0.11.0"
       },
       "devDependencies": {
         "vite": "^8.0.16",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.10.0.tgz",
-      "integrity": "sha512-E9A9czGDxwrNBeQQBLXr0khBN2p1xZWvNtqeivL4oDHnr6Ts4WaFnjjl3NAYqh8GonBjVfpuqJKtAxx7KHWBNQ==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.11.0.tgz",
+      "integrity": "sha512-SUATx6j12UC0lQblAo/Tt9ZHUOyIgI1CeFdbPZ3Jx7cLzfBzO+AODHnXTHEXNq/DMNXocvaOV7UufS450k5YWw==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.10.0"
+    "@geolonia/geonicdb-sdk": "^0.11.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -2,15 +2,17 @@
  * app.js — アプリケーションのオーケストレーション
  *
  * GeonicDB SDK を使ったリアルタイムモニターの実装。
- * SDK の API 呼び出し（db.request(), db.getEntities(), db.on(), db.subscribe(),
- * db.connect()）はすべてこのファイルに集約されており、サンプルコードとして
- * SDK の使い方が一目で分かるようになっている。
+ * SDK の API 呼び出しはすべてこのファイルに集約されており、サンプルコードとして
+ * SDK の使い方が一目で分かるようになっている。生の URL を組み立てる
+ * db.request() ではなく、型付きの高レベルメソッドを優先して使う。
  *
- * 利用している GeonicDB 機能:
- * - NGSI-LD エンティティの取得（REST API）
- * - Temporal API による時系列データの取得
- * - WebSocket によるリアルタイムのエンティティ作成・更新通知
- * - Bearer JWT 認証とトークンの自動リフレッシュ
+ * 利用している SDK メソッド / 機能:
+ * - db.getTypes()            … 登録済みエンティティタイプの一覧
+ * - db.getEntities(params)   … NGSI-LD エンティティの取得（type / limit / offset 等）
+ * - db.getTemporalEntities() … Temporal API による時系列データの取得
+ * - db.count(params)         … 件数の取得（NGSILD-Results-Count）
+ * - db.subscribe() / connect() / on() … WebSocket リアルタイム通知
+ * - Bearer JWT 認証とトークンの自動リフレッシュ（SDK が透過的に処理）
  */
 
 import { AuthenticationError, AuthorizationError } from '@geolonia/geonicdb-sdk';
@@ -37,10 +39,9 @@ if (!ENTITY_TYPE) {
     var val = document.getElementById('type-input').value;
     if (val) location.href = '?type=' + encodeURIComponent(val);
   };
-  // NGSI-LD /types API でエンティティタイプ一覧を取得（SDK経由で認証ヘッダー自動付与）
+  // エンティティタイプ一覧を取得（認証ヘッダーは SDK が自動付与）
   var select = document.getElementById('type-input');
-  // db.request() はパース済み JSON を直接返す（Response オブジェクトではない）
-  db.request('GET', '/ngsi-ld/v1/types')
+  db.getTypes()
   .then(function(types) {
     select.innerHTML = '<option value="" disabled selected>エンティティタイプを選択...</option>';
     types.forEach(function(t) {
@@ -77,9 +78,8 @@ if (ENTITY_TYPE !== '__none__') {
   currentOpt.selected = true;
   appTypeSelect.appendChild(currentOpt);
 
-  // タイプ一覧を非同期で取得してプルダウンに追加（SDK経由で認証ヘッダー自動付与）
-  // db.request() はパース済み JSON を直接返す（Response オブジェクトではない）
-  db.request('GET', '/ngsi-ld/v1/types')
+  // タイプ一覧を非同期で取得してプルダウンに追加（認証ヘッダーは SDK が自動付与）
+  db.getTypes()
   .then(function(types) {
     appTypeSelect.innerHTML = '';
     types.forEach(function(t) {
@@ -133,7 +133,7 @@ var feedDeps = {
 // 認証エラー判定
 // ============================================================
 
-/** エラーが認証エラー（401/403）かどうかを判定する。SDK v0.3.0 の型付きエラークラスを使用。 */
+/** エラーが認証エラー（401/403）かどうかを判定する。SDK の型付きエラークラス（instanceof で判定可能）を使用。 */
 function isAuthError(err) {
   return err instanceof AuthenticationError || err instanceof AuthorizationError;
 }
@@ -173,7 +173,6 @@ document.addEventListener('visibilitychange', function() {
 
 /**
  * NGSI-LD Temporal API からエンティティの時系列データを取得する。
- * SDK の request() を使うことで認証ヘッダーが自動付与される。
  *
  * Temporal API は時系列属性のみ返すため、location や name などの
  * 静的属性は通常の entities API から取得してマージする。
@@ -186,16 +185,15 @@ function fetchTemporalEntities(type) {
   var localTemporalRaw = {};
   var thisLoadToken = activeLoadToken;
 
-  // db.request() はパース済み JSON を直接返す（Response オブジェクトではない）
-  var temporalPromise = db.request('GET', '/ngsi-ld/v1/temporal/entities?type=' + encodeURIComponent(type) + '&limit=1000')
+  var temporalPromise = db.getTemporalEntities({ type: type, limit: 1000 })
     .then(function(rawEntities) {
       if (!Array.isArray(rawEntities)) rawEntities = [];
       rawEntities.forEach(function(te) { localTemporalRaw[te.id] = te; });
       return rawEntities;
     });
 
-  // sysAttrs を指定して createdAt/modifiedAt を取得する
-  var entitiesPromise = db.request('GET', '/ngsi-ld/v1/entities?type=' + encodeURIComponent(type) + '&limit=1000&options=sysAttrs');
+  // options: 'sysAttrs' で createdAt/modifiedAt（システム属性）も取得する
+  var entitiesPromise = db.getEntities({ type: type, limit: 1000, options: 'sysAttrs' });
 
   return Promise.all([temporalPromise, entitiesPromise])
     .then(function(results) {
@@ -287,10 +285,9 @@ function fitBoundsToEntities() {
   }
 }
 
-/** 通常 entities API から1ページ取得する */
+/** 通常 entities API から1ページ取得する（options: 'sysAttrs' で createdAt/modifiedAt も取得） */
 function fetchEntitiesPage(type, offset, limit) {
-  return db.request('GET', '/ngsi-ld/v1/entities?type=' + encodeURIComponent(type)
-    + '&limit=' + limit + '&offset=' + offset + '&options=sysAttrs');
+  return db.getEntities({ type: type, limit: limit, offset: offset, options: 'sysAttrs' });
 }
 
 /**
@@ -458,7 +455,7 @@ wsDot.classList.add('connecting');
 
 /** エンティティの作成・更新イベントを処理し、UI を更新する */
 function handleEntity(msg, isNew) {
-  // SDK v0.3.0: WebSocket イベントに完全な NGSI-LD エンティティが含まれる
+  // WebSocket イベント（EntityEvent）には完全な NGSI-LD エンティティが entity に含まれる
   var entity = msg.entity;
   if (!entity || entity.type !== ENTITY_TYPE) return;
   // エンティティ一覧を更新（新規は追加、既存は上書き）

--- a/src/main.js
+++ b/src/main.js
@@ -3,11 +3,11 @@
  *
  * 認証フロー:
  *   1. DPoP セッションは db.restoreSession() で再水和する
- *      (SDK 0.10.0+ が非抽出 CryptoKey ごと IndexedDB に永続化する #1230)
+ *      (SDK 0.11.0+ が非抽出 CryptoKey ごと IndexedDB に永続化する #1230)
  *   2. 保存済みトークンが Bearer なら db.setCredentials() で復元
  *   3. どちらも無ければログインフォームで
- *      db.login(..., { dpop: true, dpopPersist: true }) を呼ぶ
- *      (RFC 9449 DPoP 送信者制約セッション、XSS 漏洩耐性のため)
+ *      db.login(..., { rememberSession: true }) を呼ぶ
+ *      (DPoP 送信者制約は SDK が透過的に適用、XSS 漏洩耐性のため)
  *   4. initApp(db, auth) でアプリを起動
  */
 
@@ -60,7 +60,7 @@ var auth = getStoredAuth();
 (async function boot() {
 
 // DPoP-bound セッション (RFC 9449) はクライアントの非抽出 ECDSA 秘密鍵に
-// 紐付くトークンを発行する。SDK 0.10.0+ では dpopPersist:true でログインすると、
+// 紐付くトークンを発行する。SDK 0.11.0+ では rememberSession:true でログインすると、
 // その鍵が non-extractable CryptoKey のまま IndexedDB に保存される (#1230)。
 // 構造化複製で鍵は extractable:false を保ったままリロードを跨いで生き残るため、
 // restoreSession() で鍵とトークンを再水和できる。
@@ -148,13 +148,13 @@ if (auth && auth.accessToken && auth.tenant) {
     errorEl.textContent = '';
 
     // SDK の db.login() でログイン
-    // { dpop: true } で /auth/dpop-bind を経由して DPoP 送信者制約セッション
-    // (RFC 9449) に交換する。トークンが localStorage から XSS で漏洩しても、
-    // SDK インスタンスの非抽出秘密鍵がなければ再利用不可。
-    // { dpopPersist: true } で鍵とトークンを IndexedDB に永続化し (SDK 0.10.0+)、
+    // DPoP 送信者制約セッション (RFC 9449) は SDK 0.11.0+ が透過的に適用する
+    // (login 時に /auth/dpop-bind を内部で経由)。トークンが localStorage から
+    // XSS で漏洩しても、SDK インスタンスの非抽出秘密鍵がなければ再利用不可。
+    // { rememberSession: true } で鍵とトークンを IndexedDB に永続化し、
     // リロード後も restoreSession() で復元できるようにする (#1230)。
     var db = new GeonicDB({ baseUrl: geonicdbUrl, tenant: tenant });
-    db.login(email, password, { dpop: true, dpopPersist: true }).then(function(data) {
+    db.login(email, password, { rememberSession: true }).then(function(data) {
       var auth = {
         email: email,
         accessToken: data.accessToken,


### PR DESCRIPTION
## 概要

`@geolonia/geonicdb-sdk` を最新の **0.11.0** に更新し、あわせて pulse の趣旨（SDK のリファレンス実装）に沿って SDK の使い方が一読で分かるようコードを整理した。

## 変更内容

### 1. SDK を 0.11.0 に更新
- `@geolonia/geonicdb-sdk` を `^0.10.0` → `^0.11.0`

### 2. login オプションを新 API に移行（0.11.0 の breaking change 対応）
0.11.0 で login オプションの API が変わったため `src/main.js` を追従:
- `dpop: true` → **廃止**（DPoP 送信者制約は SDK が透過的に自動適用）
- `dpopPersist: true` → **`rememberSession: true`** にリネーム

```js
// before
db.login(email, password, { dpop: true, dpopPersist: true })
// after
db.login(email, password, { rememberSession: true })
```

`restoreSession()` / `setCredentials()` / `tokenType` 判定は API 互換のため変更なし。

### 3. 生の db.request() を型付き高レベルメソッドに統一（`src/app.js`）
サンプルとして SDK の抽象化が見えるよう、URL を手組みする `db.request()` を高レベルメソッドへ:

| Before | After |
|---|---|
| `db.request('GET', '/ngsi-ld/v1/types')` | `db.getTypes()` |
| `db.request('GET', '/ngsi-ld/v1/temporal/entities?type='+...+'&limit=1000')` | `db.getTemporalEntities({ type, limit: 1000 })` |
| `db.request('GET', '/ngsi-ld/v1/entities?type='+...+'&options=sysAttrs')` | `db.getEntities({ type, limit, offset, options: 'sysAttrs' })` |

- ファイル冒頭コメントを実態に合わせて修正
- 古い SDK バージョン参照・冗長コメントを整理

挙動はすべて等価（いずれもパース済み JSON を返す）。

## 検証
- `npm run build` 通過（pulse は lint/test スクリプトなし、build が CI 相当）

## 関連
- SDK 側の型定義不足（`GetEntitiesParams` に `options` が無い）を geolonia/geonicdb#1248 で issue 化済み

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * SDK依存関係を最新版に更新
  
* **Refactor**
  * 内部APIの呼び出しを高レベルメソッドに統一
  * セッション永続化メカニズムを改善（より効率的な秘密鍵管理を実装）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->