### PR TITLE
chore: GeonicDB SDK を 0.14.0 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.11.0"
+        "@geolonia/geonicdb-sdk": "^0.14.0"
       },
       "devDependencies": {
         "vite": "^8.0.16",
@@ -50,10 +50,22 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.11.0.tgz",
-      "integrity": "sha512-SUATx6j12UC0lQblAo/Tt9ZHUOyIgI1CeFdbPZ3Jx7cLzfBzO+AODHnXTHEXNq/DMNXocvaOV7UufS450k5YWw==",
-      "license": "MIT"
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.14.0.tgz",
+      "integrity": "sha512-f3Unw9g+gDkZb+7WClBpT5sFns18bVSVS2OHLa70g+6C7IOSLyfE2gzYhNlE3LlrMTJ/x5m0Ne67EqDzqZQCWg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@geolonia/embed": "^1.0.0",
+        "react": "^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@geolonia/embed": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.11.0"
+    "@geolonia/geonicdb-sdk": "^0.14.0"
   }
 }


### PR DESCRIPTION
## GeonicDB SDK を 0.14.0 に更新

`@geolonia/geonicdb-sdk` を `^0.11.0` → `^0.14.0` に更新。

### 背景
- 本体で v0.14.0 をリリース（#1290: NGSIv2 サブパスクライアントにジオクエリオプション `georel`/`geometry`/`coords` を追加）。npm 公開済み。
- pulse は SDK のサンプルプロジェクトとして、本体リリースへの追従を維持する。

### 変更内容
- `package.json`: `@geolonia/geonicdb-sdk` `^0.11.0` → `^0.14.0`
- `package-lock.json`: registry の `0.14.0` に解決

### 検証
- `npm install` → node_modules 実体 `0.14.0`（exports に `./ngsi-v2` / `./react` 追加を確認）
- `npm run build`（vite）→ ✅ 通過（16 modules transformed）
- pulse のコア SDK 利用（`import GeonicDB`、`AuthenticationError`/`AuthorizationError`）に破壊的変更なし

### 補足
- `^0.11.0` は 0.x キャレットで `<0.12.0` のため、明示的な範囲更新が必要だった。
- pulse はコア SDK を利用しており、#1290 の ngsi-v2 ジオクエリ自体は直接は使用しない。本 PR は純粋なバージョン追従。

https://claude.ai/code/session_01LTVNKv1Pnmrde5KubCfAmo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 地理情報関連の機能で利用するライブラリを新しいバージョンに更新しました。
  * これにより、今後の互換性や安定性の向上が期待されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->