### PR TITLE
chore: GeonicDB SDK を 0.16.0 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "geonicdb-pulse",
       "version": "1.0.0",
       "dependencies": {
-        "@geolonia/geonicdb-sdk": "^0.14.0"
+        "@geolonia/geonicdb-sdk": "^0.16.0"
       },
       "devDependencies": {
         "vite": "^8.0.16",
@@ -50,9 +50,9 @@
       }
     },
     "node_modules/@geolonia/geonicdb-sdk": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.14.0.tgz",
-      "integrity": "sha512-f3Unw9g+gDkZb+7WClBpT5sFns18bVSVS2OHLa70g+6C7IOSLyfE2gzYhNlE3LlrMTJ/x5m0Ne67EqDzqZQCWg==",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@geolonia/geonicdb-sdk/-/geonicdb-sdk-0.16.0.tgz",
+      "integrity": "sha512-oNOZe2e9YdPH6EwSS3igIWwzx2eP1/nfuGxZdgqur2sFaUI9Tqkh0PfpmyuxPPFUAhT8KF4gGV6rI15i4vY0OQ==",
       "license": "MIT",
       "peerDependencies": {
         "@geolonia/embed": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,6 @@
     "vite-plugin-minify": "^2.1.0"
   },
   "dependencies": {
-    "@geolonia/geonicdb-sdk": "^0.14.0"
+    "@geolonia/geonicdb-sdk": "^0.16.0"
   }
 }

--- a/src/app.js
+++ b/src/app.js
@@ -42,11 +42,11 @@ if (!ENTITY_TYPE) {
   // エンティティタイプ一覧を取得（認証ヘッダーは SDK が自動付与）
   var select = document.getElementById('type-input');
   db.getTypes()
-  .then(function(types) {
+  .then(function(res) {
     select.innerHTML = '<option value="" disabled selected>エンティティタイプを選択...</option>';
-    types.forEach(function(t) {
-      // typeName があればそれを使い、なければ URN の末尾を短縮名とする
-      var name = t.typeName || t.id.split(':').pop();
+    // GET /types は ETSI 準拠の EntityTypeList オブジェクトを返す。
+    // 型名の配列は typeList に入っている。
+    res.typeList.forEach(function(name) {
       var opt = document.createElement('option');
       opt.value = name;
       opt.textContent = name;
@@ -80,10 +80,9 @@ if (ENTITY_TYPE !== '__none__') {
 
   // タイプ一覧を非同期で取得してプルダウンに追加（認証ヘッダーは SDK が自動付与）
   db.getTypes()
-  .then(function(types) {
+  .then(function(res) {
     appTypeSelect.innerHTML = '';
-    types.forEach(function(t) {
-      var name = t.typeName || t.id.split(':').pop();
+    res.typeList.forEach(function(name) {
       var opt = document.createElement('option');
       opt.value = name;
       opt.textContent = name;


### PR DESCRIPTION
## 概要

`@geolonia/geonicdb-sdk` を `^0.14.0` → `^0.16.0` に更新する。

## 破壊的変更への追従: `db.getTypes()`

0.16.0 (geonicdb#1694 / geonicdb#1706) で `GET /ngsi-ld/v1/types` のレスポンスが ETSI GS CIM 009 / OpenAPI v1.8.1 準拠の `EntityTypeList` オブジェクトに変わった。

```jsonc
// before (0.14.0): EntityType の配列
[{ "id": "...", "type": "EntityType", "typeName": "Vehicle", "attributeNames": ["..."] }]

// after (0.16.0): EntityTypeList オブジェクト
{ "id": "urn:ngsi-ld:EntityTypeList:...", "type": "EntityTypeList", "typeList": ["Vehicle"] }
```

pulse は戻り値を配列とみなして `types.forEach(...)` していたため、**現在のステージング (v0.16.0 系) ではタイプ一覧の取得が壊れている**（タイプ選択オーバーレイのプルダウンと、ヘッダーの切り替えプルダウンの 2 箇所）。型名の配列 `typeList` をそのまま使うように修正した。SDK 側も戻り値の型が `EntityTypeList` に更新されている。

## 影響なしを確認した 0.15.0 / 0.16.0 の変更

- `login()` の `newPassword` オプションと `PasswordResetRequiredError` / `TemporaryPasswordExpiredError` の追加 (geonicdb#1532) — pulse の通常ログインには影響なし
- `/ngsi-ld/v1/entities` への書き込み時の `@context` 自動注入 (geonicdb#1583) — pulse は読み取り専用
- `getAttributes()` の `AttributeList` 化 — pulse は未使用

pulse が使う `getEntities` / `getTemporalEntities` / `count` / `subscribe` / WebSocket イベント / 認証まわりに破壊的変更はない。

## 動作確認

- `npm run build` (vite) 通過
- `getTypes()` のレスポンス形状は本体 `src/api/ngsild/controllers/types.controller.ts` の実装で確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * エンティティタイプ一覧の新しいレスポンス形式に対応しました。
  * タイプ選択画面およびヘッダーの切り替えメニューで、タイプ一覧を正しく表示・選択できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->